### PR TITLE
test: fix integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ before_script:
 script:
   - make
   - make check
-  #- make integration-tests
+  - make integration-tests

--- a/Android.mk
+++ b/Android.mk
@@ -22,11 +22,12 @@ osal_c_includes := \
     external/e2fsprogs/lib
 
 osal_src_files := \
-    os/os_android.c \
-    os/os_posix.c \
-    os.c
+    src/os_android.c \
+    src/os_posix.c \
+    src/os.c
 
 include $(CLEAR_VARS)
+LOCAL_CFLAGS := -DOSAL_WRAP=1 -DOSAL_THREAD_SUPPORT=1
 LOCAL_C_INCLUDES := $(osal_c_includes)
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 LOCAL_SHARED_LIBRARIES := libdl libext2_uuid
@@ -36,6 +37,7 @@ LOCAL_SRC_FILES := $(osal_src_files)
 include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
+LOCAL_CFLAGS := -DOSAL_WRAP=1 -DOSAL_THREAD_SUPPORT=1
 LOCAL_C_INCLUDES := $(osal_c_includes)
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
 LOCAL_STATIC_LIBRARIES := libandroidifaddrs

--- a/build-sys/generate_header.sh
+++ b/build-sys/generate_header.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
 #
@@ -17,7 +17,7 @@ PROJECT_VERSION_PATCH="0"
 PROJECT_VERSION_TWEAK="0"
 PROJECT_START_YEAR="2017"
 
-INPUT_FILE=os/os.h.in
+INPUT_FILE=src/os.h.in
 INPUT_SYMBOL=@OS_FUNCTION_DEF@
 
 # Generate copyright
@@ -30,7 +30,7 @@ fi
 PROJECT_COPYRIGHT="Copyright (C) $COPYRIGHT_YEAR $PROJECT_VENDOR, All Rights Reserved."
 
 # Replace symbols in input file
-REPLACE=`unifdef os/os_posix.h $*`
+REPLACE=`unifdef src/os_posix.h $*`
 awk -v value="$REPLACE" -v symbol="$INPUT_SYMBOL" '$0 ~ symbol{gsub($0,value)}1' $INPUT_FILE | \
 	sed -e "s/@PROJECT_COPYRIGHT@/$PROJECT_COPYRIGHT/g" \
 		-e "s/@PROJECT_VERSION@/$PROJECT_VERSION/g" \

--- a/src/os_android.c
+++ b/src/os_android.c
@@ -12,7 +12,7 @@
  */
 
 #include "os.h"
-
+#include "src/os_android.h"
 os_status_t os_service_restart(
 	const char *id,
 	const char *exe,

--- a/src/os_posix.h
+++ b/src/os_posix.h
@@ -67,7 +67,7 @@ typedef char os_uuid_t[16u];
 /**
  * @brief Character sequence for a line break
  */
-#define OS_FILE_LINE_BREAK             "\n"
+#define OS_FILE_LINE_BREAK             "\\n"
 
 /**
  * @brief Seek from start of file

--- a/test/integration/time_test.c
+++ b/test/integration/time_test.c
@@ -14,7 +14,9 @@
 #include <os.h>
 
 #include "test_support.h"
-#include <time.h> /* for time() function */
+
+#include <stdlib.h> /* for getenv(), setenv(), unsetenv() functions */
+#include <time.h> /* for localtime(), time(), tzet() functions */
 
 /* test os_random */
 static void test_os_random( void **state )
@@ -98,10 +100,11 @@ static void test_os_time_elapsed( void **state )
 		os_time_sleep( test_times[i], OS_FALSE );
 		os_time_elapsed( &time_stamp, &time_elapsed );
 
-		/* depending on clock boundry time may be out by
-		 * 1 second */
-		assert_false( time_elapsed != test_times[i] &&
-			time_elapsed != test_times[i] + 1u );
+		/* depending on clock boundry and system calls, time may be
+		 * out by as much as 5% (+ 1 millisecond) */
+		assert_in_range( time_elapsed,
+			test_times[i],
+			(os_millisecond_t)((double)test_times[i] * 1.05) + 1u );
 	}
 }
 
@@ -110,92 +113,255 @@ static void test_os_time_format( void **state )
 {
 	struct symbol_result_table {
 		const char *symbol;
-		const char *gmt_result;
-		const char *local_result;
+		const char *result;
 	};
-
-	unsigned int i;
-	struct symbol_result_table tests[] = {
-		{ "%%a = %a", "%a = Thu",                      "%a = Wed" },
-		{ "%%A = %A", "%A = Thursday",                 "%A = Wednesday" },
-		{ "%%b = %b", "%b = Jan",                      "%b = Dec" },
-		{ "%%B = %B", "%B = January",                  "%B = December" },
-#ifdef _WIN32
-		{ "%%c = %c", "%c = 1/1/1970",                 "%c = 12/31/1969" },
-#else
-		{ "%%c = %c", "%c = Thu Jan  1 00:00:00 1970", "%c = Wed Dec 31 19:00:00 1969" },
-#endif
-		{ "%%C = %C", "%C = 19",                       "%C = 19" },
-		{ "%%d = %d", "%d = 01",                       "%d = 31" },
-		{ "%%D = %D", "%D = 01/01/70",                 "%D = 12/31/69" },
-		{ "%%e = %e", "%e =  1",                       "%e = 31" },
-		/* { "%%E = %E", "%E = ",                         "%E = " }, - modifier symbol */
-		{ "%%F = %F", "%F = 1970-01-01",               "%F = 1969-12-31" },
-#ifdef _WIN32
-		{ "%%G = %G", "%G = 1970",                     "%G = 1969" },
-		{ "%%g = %g", "%g = 70",                       "%g = 69" },
-#else
-		{ "%%G = %G", "%G = 1970",                     "%G = 1970" },
-		{ "%%g = %g", "%g = 70",                       "%g = 70" },
-#endif
-		{ "%%h = %h", "%h = Jan",                      "%h = Dec" },
-		{ "%%H = %H", "%H = 00",                       "%H = 19" },
-		{ "%%I = %I", "%I = 12",                       "%I = 07" },
-		{ "%%j = %j", "%j = 001",                      "%j = 365" },
-		{ "%%k = %k", "%k =  0",                       "%k = 19" },
-		{ "%%l = %l", "%l = 12",                       "%l =  7" },
-		{ "%%m = %m", "%m = 01",                       "%m = 12" },
-		{ "%%M = %M", "%M = 00",                       "%M = 00" },
-		{ "%%n = %n", "%n = \n",                       "%n = \n" },
-		/* { "%%O = %O", "%O = ",                         "%O = " }, - modifier symbol */
-		{ "%%p = %p", "%p = AM",                       "%p = PM" },
-		{ "%%P = %P", "%P = am",                       "%P = pm" },
-		{ "%%r = %r", "%r = 12:00:00 AM",              "%r = 07:00:00 PM" },
-		{ "%%R = %R", "%R = 00:00",                    "%R = 19:00" },
-		/*{ "%%s = %s", "%s = 18000",                     "%s = 18000" }, - system offset from epoch using current timestamp */
-		{ "%%S = %S", "%S = 00",                       "%S = 00" },
-		{ "%%t = %t", "%t = \t",                       "%t = \t" },
-		{ "%%T = %T", "%T = 00:00:00",                 "%T = 19:00:00" },
-		{ "%%u = %u", "%u = 4",                        "%u = 3" },
-		{ "%%U = %U", "%U = 00",                       "%U = 52" },
-		{ "%%V = %V", "%V = 01",                       "%V = 01" },
-		{ "%%w = %w", "%w = 4",                        "%w = 3" },
-		{ "%%W = %W", "%W = 00",                       "%W = 52" },
-#ifdef _WIN32
-		{ "%%x = %x", "%x = 1/1/1970",                 "%x = 12/31/1969" },
-		{ "%%X = %X", "%X = 12:00:00 AM",              "%X = 7:00:00 PM" },
-#else
-		{ "%%x = %x", "%x = 01/01/70",                 "%x = 12/31/69" },
-		{ "%%X = %X", "%X = 00:00:00",                 "%X = 19:00:00" },
-#endif
-		{ "%%y = %y", "%y = 70",                       "%y = 69" },
-		{ "%%Y = %Y", "%Y = 1970",                     "%Y = 1969" },
-		{ "%%z = %z", "%z = +0000",                    "%z = -0500" },
-#ifdef _WIN32
-		{ "%%Z = %Z", "%Z = GMT",                      "%Z = Eastern Standard Time" },
-#else
-		{ "%%Z = %Z", "%Z = GMT",                      "%Z = EST" },
-#endif
-		{ "%%%% = %%", "%% = %",                       "%% = %" },
-	};
+	unsigned int i = 0u;
+	time_t tz_offset = 0; /* time zone offset in seconds */
+	int to_local_time = 0;
 	os_timestamp_t ts = 0u;
 
-	for ( i = 0u; i < sizeof( tests ) / sizeof( struct symbol_result_table ); ++i )
-	{
-		char buf[ 256u ];
-		os_time_format( buf, 256u, tests[i].symbol, ts, OS_FALSE );
-		assert_string_equal( buf, tests[i].gmt_result );
-		os_time_format( buf, 256u, tests[i].symbol, ts, OS_TRUE );
-		assert_string_equal( buf, tests[i].local_result );
-	}
-}
+	struct symbol_result_table tests[] = {
+		{ "%%a = %a", "%a = Thu" },
+		{ "%%A = %A", "%A = Thursday" },
+		{ "%%b = %b", "%b = Jan" },
+		{ "%%B = %B", "%B = January" },
+#ifdef _WIN32
+		{ "%%c = %c", "%c = 1/1/1970" },
+#else
+		{ "%%c = %c", "%c = Thu Jan  1 00:00:00 1970" },
+#endif
+		{ "%%C = %C", "%C = 19" },
+		{ "%%d = %d", "%d = 01" },
+		{ "%%D = %D", "%D = 01/01/70" },
+		{ "%%e = %e", "%e =  1" },
+		/* { "%%E = %E", "%E = " }, - modifier symbol */
+		{ "%%F = %F", "%F = 1970-01-01" },
+		{ "%%G = %G", "%G = 1970" },
+		{ "%%g = %g", "%g = 70" },
+		{ "%%h = %h", "%h = Jan" },
+		{ "%%H = %H", "%H = 00" },
+		{ "%%I = %I", "%I = 12" },
+		{ "%%j = %j", "%j = 001" },
+		{ "%%k = %k", "%k =  0" },
+		{ "%%l = %l", "%l = 12" },
+		{ "%%m = %m", "%m = 01" },
+		{ "%%M = %M", "%M = 00" },
+		{ "%%n = %n", "%n = \n" },
+		/* { "%%O = %O", "%O = " }, - modifier symbol */
+		{ "%%p = %p", "%p = AM" },
+#ifdef __APPLE__
+		{ "%%P = %P", "%P = P" },
+#else
+		{ "%%P = %P", "%P = am" },
+#endif
+		{ "%%r = %r", "%r = 12:00:00 AM" },
+		{ "%%R = %R", "%R = 00:00" },
+		/*{ "%%s = %s", "%s = 18000" }, - system offset from epoch using current timestamp */
+		{ "%%S = %S", "%S = 00" },
+		{ "%%t = %t", "%t = \t" },
+		{ "%%T = %T", "%T = 00:00:00" },
+		{ "%%u = %u", "%u = 4" },
+		{ "%%U = %U", "%U = 00" },
+		{ "%%V = %V", "%V = 01" },
+		{ "%%w = %w", "%w = 4" },
+		{ "%%W = %W", "%W = 00" },
+#ifdef _WIN32
+		{ "%%x = %x", "%x = 1/1/1970" },
+		{ "%%X = %X", "%X = 12:00:00 AM" },
+#else
+		{ "%%x = %x", "%x = 01/01/70" },
+		{ "%%X = %X", "%X = 00:00:00" },
+#endif
+		{ "%%y = %y", "%y = 70" },
+		{ "%%Y = %Y", "%Y = 1970" },
+		{ "%%z = %z", "%z = +0000" },
+		/* { "%%Z = %Z", "%Z = GMT" }, - not consistent on all platforms */
+		{ "%%%% = %%", "%% = %" }
+	};
 
-/* test os_time_remaining */
-static void test_os_time_remaining( void **state )
-{
-	unsigned int i;
-	os_status_t result;
-	const os_millisecond_t test_times[] = {
+#ifdef _WIN32
+	{
+		TIME_ZONE_INFORMATION tzi;
+		if ( GetTimeZoneInformationForYear( 1970 + (USHORT)(ts / 3.154e+10), NULL, &tzi ) )
+		{
+			tz_offset = tzi.Bias * -60;
+		}
+	}
+#else
+	{
+		time_t gmt_time = (time_t)ts;
+		struct tm *local;
+		char *tz;
+
+		/* not thread safe (but this is okay) as this program runs in a
+		 * single thread.  This calculates the offset for the time zon
+		 */
+		local = localtime( &gmt_time );
+		tz = getenv( "TZ" );
+		setenv( "TZ", "UTC", 1 );
+		tzset();
+		tz_offset = mktime( local );
+		if ( tz )
+			setenv( "TZ", tz, 1 );
+		else
+			unsetenv("TZ");
+		tzset();
+	}
+#endif
+
+	for ( to_local_time = 0; to_local_time < 2; ++to_local_time )
+	{
+		if ( to_local_time )
+		{
+			unsigned int j = 0;
+			if ( tz_offset < 0 )
+			{
+				tests[j++].result = "%a = Wed";
+				tests[j++].result = "%A = Wednesday";
+				tests[j++].result = "%b = Dec";
+				tests[j++].result = "%B = December";
+#ifdef _WIN32
+				tests[j++].result = "%c = 12/31/1969";
+#else
+				tests[j++].result = "%c = Wed Dec 31 19:00:00 1969";
+#endif
+				tests[j++].result = "%C = 19";
+				tests[j++].result = "%d = 31";
+				tests[j++].result = "%D = 12/31/69";
+				tests[j++].result = "%e = 31";
+				/* tests[j++].result = "%E = "; - modifier symbol */
+				tests[j++].result = "%F = 1969-12-31";
+#ifdef _WIN32
+				tests[j++].result = "%G = 1969";
+				tests[j++].result = "%g = 69";
+#else
+				/** @todo fix this bug */
+				tests[j++].result = "%G = 1970";
+				tests[j++].result = "%g = 70";
+#endif
+				tests[j++].result = "%h = Dec";
+				tests[j++].result = "%H = 19";
+				tests[j++].result = "%I = 07";
+				tests[j++].result = "%j = 365";
+				tests[j++].result = "%k = 19";
+				tests[j++].result = "%l =  7";
+				tests[j++].result = "%m = 12";
+				tests[j++].result = "%M = 00";
+				tests[j++].result = "%n = \n";
+				/* tests[j++].result = "%O = "; - modifier symbol */
+				tests[j++].result = "%p = PM";
+#ifdef __APPLE__
+				tests[j++].result = "%P = P";
+#else
+				tests[j++].result = "%P = pm";
+#endif
+				tests[j++].result = "%r = 07:00:00 PM";
+				tests[j++].result = "%R = 19:00";
+				/* tests[j++].result = "%s = 18000"; - modifier symbol */
+				tests[j++].result = "%S = 00";
+				tests[j++].result = "%t = \t";
+				tests[j++].result = "%T = 19:00:00";
+				tests[j++].result = "%u = 3";
+				tests[j++].result = "%U = 52";
+				tests[j++].result = "%V = 01";
+				tests[j++].result = "%w = 3";
+				tests[j++].result = "%W = 52";
+#ifdef _WIN32
+				tests[j++].result = "%x = 12/31/1969";
+				tests[j++].result = "%X = 7:00:00 PM";
+#else
+				tests[j++].result = "%x = 12/31/69";
+				tests[j++].result = "%X = 19:00:00";
+#endif
+				tests[j++].result = "%y = 69";
+				tests[j++].result = "%Y = 1969";
+				tests[j++].result = "%z = -0500";
+/* not consistent on all platforms
+#ifdef _WIN32
+				tests[j++].result = "%Z = Eastern Standard Time";
+#else
+				tests[j++].result = "%Z = EST";
+#endif
+*/
+				tests[j++].result = "%% = %";
+			}
+			else
+			{
+				tests[j++].result = "%a = Thu";
+				tests[j++].result = "%A = Thursday";
+				tests[j++].result = "%b = Jan";
+				tests[j++].result = "%B = January";
+#ifdef _WIN32
+				tests[j++].result = "%c = 1/1/1970";
+#else
+				tests[j++].result = "%c = Thu Jan  1 00:00:00 1970";
+#endif
+				tests[j++].result = "%C = 19";
+				tests[j++].result = "%d = 01";
+				tests[j++].result = "%D = 01/01/70";
+				tests[j++].result = "%e =  1";
+				/* tests[j++].result = "%E = "; - modifier symbol */
+				tests[j++].result = "%F = 1970-01-01";
+				tests[j++].result = "%G = 1970";
+				tests[j++].result = "%g = 70";
+				tests[j++].result = "%h = Jan";
+				tests[j++].result = "%H = 00";
+				tests[j++].result = "%I = 12";
+				tests[j++].result = "%j = 001";
+				tests[j++].result = "%k =  0";
+				tests[j++].result = "%l = 12";
+				tests[j++].result = "%m = 01";
+				tests[j++].result = "%M = 00";
+				tests[j++].result = "%n = \n";
+				/* tests[j++].result = "%O = "; - modifier symbol */
+				tests[j++].result = "%p = AM";
+#ifdef __APPLE__
+				tests[j++].result = "%P = P";
+#else
+				tests[j++].result = "%P = am";
+#endif
+				tests[j++].result = "%r = 12:00:00 AM";
+				tests[j++].result = "%R = 00:00";
+				/* tests[j++].result = "%s = 0"; - modifier symbol */
+				tests[j++].result = "%S = 00";
+				tests[j++].result = "%t = \t";
+				tests[j++].result = "%T = 00:00:00";
+				tests[j++].result = "%u = 4";
+				tests[j++].result = "%U = 00";
+				tests[j++].result = "%V = 01";
+				tests[j++].result = "%w = 4";
+				tests[j++].result = "%W = 00";
+#ifdef _WIN32
+				tests[j++].result = "%x = 1/1/1970";
+				tests[j++].result = "%X = 12:00:00 AM";
+#else
+				tests[j++].result = "%x = 01/01/70";
+				tests[j++].result = "%X = 00:00:00";
+#endif
+				tests[j++].result = "%y = 70";
+				tests[j++].result = "%Y = 1970";
+				tests[j++].result = "%z = +0000";
+				/* tests[j++].result = "%Z = GMT"; not consistent on all platforms */
+				tests[j++].result = "%% = %";
+			}
+		}
+
+		for ( i = 0u; i < sizeof( tests ) / sizeof( struct symbol_result_table ); ++i )
+		{
+				char buf[ 256u ];
+				os_time_format( buf, 256u,
+					tests[i].symbol, ts, to_local_time );
+				assert_string_equal( buf, tests[i].result );
+			}
+		}
+	}
+
+	/* test os_time_remaining */
+	static void test_os_time_remaining( void **state )
+	{
+		unsigned int i;
+		os_status_t result;
+		const os_millisecond_t test_times[] = {
 		0u,       /* 0 milliseconds */
 		500u,     /* 500 milliseconds */
 		1000u,    /* 1 second */


### PR DESCRIPTION
This patch fixes the time integration tests to work better in other time
zones then EST.  However, this fix only works for systems in GMT as well
as EST.  Eventually, this test will be needed to be fixed for all time
zones.

Signed-off-by: Keith Holman <keith.holman@windriver.com>