### PR TITLE
build: remove sudo requirement from travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 language: c
 compiler:
   - clang
@@ -14,21 +14,26 @@ env:
     - OSAL_THREAD_SUPPORT=ON  OSAL_WRAP=ON  BUILD_TYPE=Debug
     - OSAL_THREAD_SUPPORT=ON  OSAL_WRAP=ON  BUILD_TYPE=Release
 install:
+  - export DEPS_DIR=`pwd`/deps
+  - mkdir -p $DEPS_DIR
+
+  # cmocka
   - wget https://cmocka.org/files/1.1/cmocka-1.1.1.tar.xz
   - tar -xvf cmocka-1.1.1.tar.xz
   - cd cmocka-1.1.1
   - mkdir build
   - cd build
-  - cmake -DCMAKE_BUILD_TYPE:STRING=Debug ..
+  - cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX:PATH=$DEPS_DIR ..
   - make
-  - sudo make install
+  - make install
   - cd ../..
   - rm -rf cmocka-1.1.1
+
 before_script:
   - mkdir build
   - cd build
   - cmake --version
-  - cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DOSAL_THREAD_SUPPORT:BOOL=$OSAL_THREAD_SUPPORT -DOSAL_WRAP:BOOL=$OSAL_WRAP ..
+  - cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DDEPENDS_ROOT_DIR:PATH=$DEPS_DIR -DOSAL_THREAD_SUPPORT:BOOL=$OSAL_THREAD_SUPPORT -DOSAL_WRAP:BOOL=$OSAL_WRAP ..
 
 script:
   - make

--- a/build-sys/cmake/FindCmocka.cmake
+++ b/build-sys/cmake/FindCmocka.cmake
@@ -1,14 +1,16 @@
 #
 # cmocka support
 #
+# The following variables can be set to add additional find support:
+# - CMOCKA_ROOT_DIR, specified an explicit root path to test
+#
 # If found the following will be defined:
-# CMOCKA_FOUND - System has cmocka
-# CMOCKA_INCLUDE_DIRS/CMOCKA_INCLUDES - Include directories for cmocka
-# CMOCKA_LIBRARIES/CMOCKA_LIBS - Libraries needed for cmocka
-# CMOCKA_DEFINITIONS - Compiler switches required for cmocka
+# - CMOCKA_FOUND - System has cmocka
+# - CMOCKA_INCLUDE_DIRS/CMOCKA_INCLUDES - Include directories for cmocka
+# - CMOCKA_LIBRARIES/CMOCKA_LIBS - Libraries needed for cmocka
+# - CMOCKA_DEFINITIONS - Compiler switches required for cmocka
 #
-#
-# Copyright (C) 2015 Wind River Systems, Inc. All Rights Reserved.
+# Copyright (C) 2015-2017 Wind River Systems, Inc. All Rights Reserved.
 #
 # The right to copy, distribute or otherwise make use of this software may
 # be licensed only pursuant to the terms of an applicable Wind River license
@@ -20,17 +22,33 @@ include( FindPackageHandleStandardArgs )
 
 set( _PROGRAMFILES     "ProgramFiles" )
 set( _PROGRAMFILES_X86 "ProgramFiles(x86)" )
+
+# Try and find paths
+set( LIB_SUFFIX "" )
+get_property( LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS )
+if( LIB64 )
+	set( LIB_SUFFIX 64 )
+endif()
+
+# Allow the ability to specify a global dependency root directory
+if ( NOT CMOCKA_ROOT_DIR )
+	set( CMOCKA_ROOT_DIR ${DEPENDS_ROOT_DIR} )
+endif()
+
 find_path( CMOCKA_INCLUDE_DIR
 	NAMES cmocka.h
 	DOC "cmocka include directory"
-	PATHS "$ENV{${_PROGRAMFILES}}/cmocka/include"
+	PATHS "${CMOCKA_ROOT_DIR}/include"
+	      "$ENV{${_PROGRAMFILES}}/cmocka/include"
 	      "$ENV{${_PROGRAMFILES_X86}}/cmocka/include"
 )
 
 find_library( CMOCKA_LIBRARY
 	NAMES cmocka
 	DOC "Required cmocka libraries"
-	PATHS "$ENV{${_PROGRAMFILES}}/cmocka/lib"
+	PATHS "${CMOCKA_ROOT_DIR}/lib${LIB_SUFFIX}"
+	      "${CMOCKA_ROOT_DIR}/lib"
+	      "$ENV{${_PROGRAMFILES}}/cmocka/lib"
 	      "$ENV{${_PROGRAMFILES_X86}}/cmocka/lib"
 )
 
@@ -40,6 +58,9 @@ set( CMOCKA_INCLUDE_DIRS ${CMOCKA_INCLUDE_DIR} )
 set( CMOCKA_INCLUDES ${CMOCKA_INCLUDE_DIRS} )
 set( CMOCKA_DEFINITIONS "" )
 
-find_package_handle_standard_args( cmocka DEFAULT_MSG CMOCKA_LIBRARY CMOCKA_INCLUDE_DIR )
+find_package_handle_standard_args( Cmocka
+	FOUND_VAR CMOCKA_FOUND
+	REQUIRED_VARS CMOCKA_INCLUDE_DIR CMOCKA_LIBRARY
+	FAIL_MESSAGE DEFAULT_MSG )
 mark_as_advanced( CMOCKA_INCLUDE_DIR CMOCKA_LIBRARY )
 


### PR DESCRIPTION
This commit updates the travis continuious integration setup to not
require a sudo access.  This will speed up linux builds as they can now
be built in a docker image, instead of requiring a full vm.

Signed-off-by: Keith Holman <keith.holman@windriver.com>