### PR TITLE
os_posix.c: fix OS_FILE_LINE_BREAK

### DIFF
--- a/src/os_posix.h
+++ b/src/os_posix.h
@@ -67,7 +67,7 @@ typedef char os_uuid_t[16u];
 /**
  * @brief Character sequence for a line break
  */
-#define OS_FILE_LINE_BREAK             "\\n"
+#define OS_FILE_LINE_BREAK             "\n"
 
 /**
  * @brief Seek from start of file


### PR DESCRIPTION
Remove a fix that was made for Android to double back slash the line
break.  That change is no longer required.

Signed-off-by: Paul Barrette <paulbarrette@gmail.com>