### PR TITLE
os: add kernel_version field for system info

### DIFF
--- a/src/os.h.in
+++ b/src/os.h.in
@@ -256,6 +256,8 @@ typedef struct os_system_info
 	char system_release[OS_SYSTEM_INFO_MAX_LEN + 1u];
 	/** @brief operating system version */
 	char system_version[OS_SYSTEM_INFO_MAX_LEN + 1u];
+	/** @brief kernel version */
+	char kernel_version[OS_SYSTEM_INFO_MAX_LEN + 1u];
 	/** @brief operating system flag */
 	os_uint8_t system_flags;
 } os_system_info_t;

--- a/src/os_win.c
+++ b/src/os_win.c
@@ -3134,6 +3134,8 @@ os_status_t os_system_info(
 				service_pack,
 				OS_SYSTEM_INFO_MAX_LEN );
 
+		os_strncpy( sys_info->kernel_version, "",
+			OS_SYSTEM_INFO_MAX_LEN );
 		os_strncpy( sys_info->vendor_name, vendor_name,
 			OS_SYSTEM_INFO_MAX_LEN );
 		os_strncpy( sys_info->system_name, system_name,


### PR DESCRIPTION
This patch adds the "kernel_version" field when retrieving system
information.  This can be useful, for outside packages.  This also
includes a minor fix when parsing MAC addresses (off by 1 error) on
Linux based systems.

Signed-off-by: Keith Holman <keith.holman@windriver.com>