### PR TITLE
Os file fixes

### DIFF
--- a/src/os.h.in
+++ b/src/os.h.in
@@ -690,38 +690,6 @@ OS_API os_status_t os_file_delete(
 OS_API os_bool_t os_file_exists(
 	const char *file_path
 );
-
-/**
- * @brief Move the current position in an file stream
- *
- * @param[in,out]  stream              stream to pointer of
- * @param[in]      offset              amount to remove file pointer
- * @param[in]      whence              where to apply the offset at
- *
- * @retval OS_STATUS_BAD_PARAMETER     bad parameter passed to the function
- * @retval OS_STATUS_FAILURE           failed to move file pointer
- * @retval OS_STATUS_SUCCESS           on success
- */
-OS_API os_status_t os_file_seek(
-	os_file_t stream,
-	long offset,
-	int whence
-);
-
-/**
- * @brief Synchronize a file's in-core state with storage device
- *
- * @param[in]      file_path           path to file to synchronize
- *
- * @retval OS_STATUS_BAD_PARAMETER     bad parameter passed to the function
- * @retval OS_STATUS_SUCCESS           successfully sync the file
- * @retval OS_STATUS_FAILURE           failed to sync file stream
- *
- */
-OS_API os_status_t os_file_sync(
-	const char *file_path
-);
-
 /**
  * @brief Get size of file in bytes
  *
@@ -783,6 +751,39 @@ OS_API os_status_t os_file_move(
 OS_API os_file_t os_file_open(
 	const char *file_path,
 	int flags
+);
+
+/**
+ * @brief Move the current position in an file stream
+ *
+ * @param[in,out]  stream              stream to pointer of open file
+ * @param[in]      offset              amount to remove file pointer
+ * @param[in]      whence              where to apply the offset at
+ *
+ * @retval OS_STATUS_BAD_PARAMETER     bad parameter passed to the function
+ * @retval OS_STATUS_FAILURE           failed to move file pointer
+ * @retval OS_STATUS_SUCCESS           on success
+ *
+ * @see os_file_tell
+ */
+OS_API os_status_t os_file_seek(
+	os_file_t stream,
+	long offset,
+	int whence
+);
+
+/**
+ * @brief Synchronize a file's in-core state with storage device
+ *
+ * @param[in]      file_path           path to file to synchronize
+ *
+ * @retval OS_STATUS_BAD_PARAMETER     bad parameter passed to the function
+ * @retval OS_STATUS_SUCCESS           successfully sync the file
+ * @retval OS_STATUS_FAILURE           failed to sync file stream
+ *
+ */
+OS_API os_status_t os_file_sync(
+	const char *file_path
 );
 
 /**

--- a/src/os.h.in
+++ b/src/os.h.in
@@ -690,27 +690,6 @@ OS_API os_status_t os_file_delete(
 OS_API os_bool_t os_file_exists(
 	const char *file_path
 );
-/**
- * @brief Get size of file in bytes
- *
- * @param[in]      file_path           path to file
- *
- * @return         File size in bytes
- */
-OS_API os_uint64_t os_file_get_size(
-	const char *file_path
-);
-
-/**
- * @brief Get size of file in bytes
- *
- * @param[in]      file_handle         file handle
- *
- * @return         File size in bytes
- */
-OS_API os_uint64_t os_file_get_size_handle(
-	os_file_t file_handle
-);
 
 /**
  * @brief Moves a file in the file system
@@ -770,6 +749,32 @@ OS_API os_status_t os_file_seek(
 	os_file_t stream,
 	long offset,
 	int whence
+);
+
+/**
+ * @brief Get size of file in bytes
+ *
+ * @param[in]      file_path           path to file
+ *
+ * @return         File size in bytes
+ *
+ * @see os_file_size_handle
+ */
+OS_API os_uint64_t os_file_size(
+	const char *file_path
+);
+
+/**
+ * @brief Get size of file in bytes
+ *
+ * @param[in]      file_handle         file handle
+ *
+ * @return         File size in bytes
+ *
+ * @see os_file_size
+ */
+OS_API os_uint64_t os_file_size_handle(
+	os_file_t file_handle
 );
 
 /**

--- a/src/os_posix.c
+++ b/src/os_posix.c
@@ -822,35 +822,6 @@ char *os_file_gets(
 }
 #endif /* if defined(OSAL_WRAP) && OSAL_WRAP */
 
-os_uint64_t os_file_get_size(
-	const char *file_path )
-{
-	struct stat file_stat;
-
-	if ( stat( file_path, &file_stat ) != 0 )
-		file_stat.st_size = 0;
-
-	return (os_uint64_t)file_stat.st_size;
-}
-
-os_uint64_t os_file_get_size_handle(
-	os_file_t file_handle )
-{
-	long file_size = 0;
-
-	if ( file_handle )
-	{
-		long cur_pos = ftell( file_handle );
-		if ( fseek( file_handle, 0, SEEK_END ) == 0 )
-		{
-			file_size = ftell( file_handle );
-			if ( cur_pos != file_size )
-				fseek( file_handle, cur_pos, SEEK_SET );
-		}
-	}
-	return (os_uint64_t)file_size;
-}
-
 os_status_t os_file_move(
 	const char *old_path,
 	const char *new_path
@@ -962,6 +933,35 @@ os_status_t os_file_seek(
 			result = OS_STATUS_SUCCESS;
 	}
 	return result;
+}
+
+os_uint64_t os_file_size(
+	const char *file_path )
+{
+	struct stat file_stat;
+
+	if ( stat( file_path, &file_stat ) != 0 )
+		file_stat.st_size = 0;
+
+	return (os_uint64_t)file_stat.st_size;
+}
+
+os_uint64_t os_file_size_handle(
+	os_file_t file_handle )
+{
+	long int file_size = 0L;
+
+	if ( file_handle )
+	{
+		long int cur_pos = ftell( file_handle );
+		if ( fseek( file_handle, 0, SEEK_END ) == 0 )
+		{
+			file_size = ftell( file_handle );
+			if ( cur_pos != file_size )
+				fseek( file_handle, cur_pos, SEEK_SET );
+		}
+	}
+	return (os_uint64_t)file_size;
 }
 
 os_status_t os_file_sync(

--- a/src/os_posix.c
+++ b/src/os_posix.c
@@ -822,52 +822,6 @@ char *os_file_gets(
 }
 #endif /* if defined(OSAL_WRAP) && OSAL_WRAP */
 
-os_status_t os_file_seek(
-	os_file_t stream,
-	long offset,
-	int whence
-)
-{
-	os_status_t result = OS_STATUS_BAD_PARAMETER;
-	if ( stream != OS_FILE_INVALID )
-	{
-		result = OS_STATUS_FAILURE;
-		if ( fseek( stream, offset, whence ) == 0 )
-			result = OS_STATUS_SUCCESS;
-	}
-	return result;
-}
-
-os_status_t os_file_sync(
-	const char *file_path )
-{
-	os_status_t result = OS_STATUS_BAD_PARAMETER;
-	if ( file_path )
-	{
-		int fd;
-		result = OS_STATUS_FAILURE;
-#ifndef _WRS_KERNEL
-		fd = open( file_path, O_RDONLY );
-#else
-		fd = open( file_path, O_RDONLY, 0 );
-#endif
-		if ( fd >= 0 )
-		{
-			if ( fsync( fd ) == 0 )
-				result = OS_STATUS_SUCCESS;
-			close( fd );
-		}
-	}
-#ifndef _WRS_KERNEL
-	else
-	{
-		sync();
-		result = OS_STATUS_SUCCESS;
-	}
-#endif
-	return result;
-}
-
 os_uint64_t os_file_get_size(
 	const char *file_path )
 {
@@ -991,6 +945,60 @@ size_t os_file_read(
 	os_file_t stream )
 {
 	return fread( ptr, size, nmemb, stream );
+}
+#endif /* if defined(OSAL_WRAP) && OSAL_WRAP */
+
+os_status_t os_file_seek(
+	os_file_t stream,
+	long offset,
+	int whence
+)
+{
+	os_status_t result = OS_STATUS_BAD_PARAMETER;
+	if ( stream != OS_FILE_INVALID )
+	{
+		result = OS_STATUS_FAILURE;
+		if ( fseek( stream, offset, whence ) == 0 )
+			result = OS_STATUS_SUCCESS;
+	}
+	return result;
+}
+
+os_status_t os_file_sync(
+	const char *file_path )
+{
+	os_status_t result = OS_STATUS_BAD_PARAMETER;
+	if ( file_path )
+	{
+		int fd;
+		result = OS_STATUS_FAILURE;
+#ifndef _WRS_KERNEL
+		fd = open( file_path, O_RDONLY );
+#else
+		fd = open( file_path, O_RDONLY, 0 );
+#endif
+		if ( fd >= 0 )
+		{
+			if ( fsync( fd ) == 0 )
+				result = OS_STATUS_SUCCESS;
+			close( fd );
+		}
+	}
+#ifndef _WRS_KERNEL
+	else
+	{
+		sync();
+		result = OS_STATUS_SUCCESS;
+	}
+#endif
+	return result;
+}
+
+#if defined(OSAL_WRAP) && OSAL_WRAP
+long int os_file_tell(
+	os_file_t stream )
+{
+	return ftell( stream );
 }
 #endif /* if defined(OSAL_WRAP) && OSAL_WRAP */
 

--- a/src/os_posix.h
+++ b/src/os_posix.h
@@ -71,19 +71,19 @@ typedef char os_uuid_t[16u];
 
 /**
  * @brief Seek from start of file
- * @see os_file_fseek
+ * @see os_file_seek
  */
 #define OS_FILE_SEEK_START             SEEK_SET
 
 /**
  * @brief Seek from current position in file
- * @see os_file_fseek
+ * @see os_file_seek
  */
 #define OS_FILE_SEEK_CURRENT           SEEK_CUR
 
 /**
  * @brief Seek from end of file
- * @see os_file_fseek
+ * @see os_file_seek
  */
 #define OS_FILE_SEEK_END               SEEK_END
 
@@ -243,6 +243,25 @@ OS_API size_t os_file_read(
 #else
 OS_API size_t os_file_puts(
 	char *str,
+	os_file_t stream
+);
+#endif
+
+/**
+ * @brief Returns the current position in a file stream
+ *
+ * @param[in,out]  stream              stream to pointer of open file
+ *
+ * @retval OS_STATUS_BAD_PARAMETER     bad parameter passed to the function
+ * @retval OS_STATUS_FAILURE           failed to move file pointer
+ * @retval OS_STATUS_SUCCESS           on success
+ *
+ * @see os_file_seek
+ */
+#if !OSAL_WRAP
+#define os_file_tell(stream)           (long int)ftell(stream)
+#else
+OS_API long int os_file_tell(
 	os_file_t stream
 );
 #endif

--- a/src/os_win.c
+++ b/src/os_win.c
@@ -881,75 +881,6 @@ char *os_file_gets(
 	return str;
 }
 
-size_t os_file_puts(
-	char *str,
-	os_file_t stream )
-{
-	DWORD len;
-	DWORD result;
-	len = (DWORD)os_strlen( str );
-	WriteFile( stream, str, len, &result, NULL );
-	return (size_t)result;
-}
-
-size_t os_file_read(
-	void *ptr,
-	size_t size,
-	size_t nmemb,
-	os_file_t stream )
-{
-	size_t result = 0;
-	if ( size > 0 && nmemb > 0 )
-	{
-		DWORD number_of_bytes_read = 0;
-		ReadFile( stream, ptr, ( size * nmemb ),
-			&number_of_bytes_read, NULL );
-		result = number_of_bytes_read / size;
-	}
-	return result;
-}
-
-os_status_t os_file_seek(
-	os_file_t stream,
-	long offset,
-	int whence
-)
-{
-	os_status_t result = OS_STATUS_BAD_PARAMETER;
-	if ( stream != OS_FILE_INVALID )
-	{
-
-		result = OS_STATUS_FAILURE;
-		if ( SetFilePointer( stream, offset, NULL, whence )
-			!= INVALID_SET_FILE_POINTER )
-			result = OS_STATUS_SUCCESS;
-	}
-	return result;
-}
-
-os_status_t os_file_sync( const char *UNUSED(file_path) )
-{
-	/* buffers will be flushed when a stream is closed */
-	return OS_STATUS_SUCCESS;
-}
-
-size_t os_file_write(
-	const void *ptr,
-	size_t size,
-	size_t nmemb,
-	os_file_t stream )
-{
-	size_t result = 0;
-	if ( size > 0 && nmemb > 0 )
-	{
-		DWORD number_of_bytes_wrote = 0;
-		WriteFile( stream, ptr, ( size * nmemb ),
-			&number_of_bytes_wrote, NULL );
-		result = number_of_bytes_wrote / size;
-	}
-	return result;
-}
-
 os_uint64_t os_file_get_size(
 	const char *file_path )
 {
@@ -1041,6 +972,77 @@ os_file_t os_file_open(
 	return result;
 }
 
+size_t os_file_puts(
+	char *str,
+	os_file_t stream )
+{
+	DWORD len;
+	DWORD result;
+	len = (DWORD)os_strlen( str );
+	WriteFile( stream, str, len, &result, NULL );
+	return (size_t)result;
+}
+
+size_t os_file_read(
+	void *ptr,
+	size_t size,
+	size_t nmemb,
+	os_file_t stream )
+{
+	size_t result = 0;
+	if ( size > 0 && nmemb > 0 )
+	{
+		DWORD number_of_bytes_read = 0;
+		ReadFile( stream, ptr, ( size * nmemb ),
+			&number_of_bytes_read, NULL );
+		result = number_of_bytes_read / size;
+	}
+	return result;
+}
+
+os_status_t os_file_seek(
+	os_file_t stream,
+	long offset,
+	int whence )
+{
+	os_status_t result = OS_STATUS_BAD_PARAMETER;
+	if ( stream != OS_FILE_INVALID )
+	{
+
+		result = OS_STATUS_FAILURE;
+		if ( SetFilePointer( stream, offset, NULL, whence )
+			!= INVALID_SET_FILE_POINTER )
+			result = OS_STATUS_SUCCESS;
+	}
+	return result;
+}
+
+os_status_t os_file_sync(
+	const char *UNUSED(file_path) )
+{
+	/* buffers will be flushed when a stream is closed */
+	return OS_STATUS_SUCCESS;
+}
+
+long int os_file_tell(
+	os_file_t stream )
+{
+	long int result = -1L;
+	if ( stream != OS_FILE_INVALID )
+	{
+		DWORD low_file_size = 0, high_file_size = 0;
+		low_file_size = GetFileSize( stream, &high_file_size );
+		if ( low_file_size != INVALID_FILE_SIZE )
+		{
+			LARGE_INTEGER large_int;
+			large_int.LowPart = low_file_size;
+			large_int.HighPart = high_file_size;
+			result = (long int)large_int.QuadPart;
+		}
+	}
+	return result;
+}
+
 os_status_t os_file_temp(
 	char *prototype,
 	size_t suffix_len )
@@ -1064,6 +1066,23 @@ os_status_t os_file_temp(
 			if ( os_file_exists( prototype ) == OS_FALSE )
 				result = OS_STATUS_SUCCESS;
 		}
+	}
+	return result;
+}
+
+size_t os_file_write(
+	const void *ptr,
+	size_t size,
+	size_t nmemb,
+	os_file_t stream )
+{
+	size_t result = 0;
+	if ( size > 0 && nmemb > 0 )
+	{
+		DWORD number_of_bytes_wrote = 0;
+		WriteFile( stream, ptr, ( size * nmemb ),
+			&number_of_bytes_wrote, NULL );
+		result = number_of_bytes_wrote / size;
 	}
 	return result;
 }

--- a/src/os_win.c
+++ b/src/os_win.c
@@ -881,32 +881,6 @@ char *os_file_gets(
 	return str;
 }
 
-os_uint64_t os_file_get_size(
-	const char *file_path )
-{
-
-	WIN32_FILE_ATTRIBUTE_DATA attr;
-	LARGE_INTEGER size;
-	LONGLONG file_size = 0;
-
-	if ( GetFileAttributesEx( file_path, GetFileExInfoStandard, &attr ) )
-	{
-		size.HighPart = attr.nFileSizeHigh;
-		size.LowPart = attr.nFileSizeLow;
-		file_size = size.QuadPart;
-	}
-	return (os_uint64_t)file_size;
-}
-
-os_uint64_t os_file_get_size_handle(
-	os_file_t file_handle )
-{
-	DWORD file_size = 0;
-	if ( file_handle )
-		file_size = GetFileSize( file_handle, NULL );
-	return (os_uint64_t)file_size;
-}
-
 os_status_t os_file_move(
 	const char *old_path,
 	const char *new_path
@@ -1015,6 +989,32 @@ os_status_t os_file_seek(
 			result = OS_STATUS_SUCCESS;
 	}
 	return result;
+}
+
+os_uint64_t os_file_size(
+	const char *file_path )
+{
+
+	WIN32_FILE_ATTRIBUTE_DATA attr;
+	LARGE_INTEGER size;
+	LONGLONG file_size = 0;
+
+	if ( GetFileAttributesEx( file_path, GetFileExInfoStandard, &attr ) )
+	{
+		size.HighPart = attr.nFileSizeHigh;
+		size.LowPart = attr.nFileSizeLow;
+		file_size = size.QuadPart;
+	}
+	return (os_uint64_t)file_size;
+}
+
+os_uint64_t os_file_size_handle(
+	os_file_t file_handle )
+{
+	DWORD file_size = 0;
+	if ( file_handle )
+		file_size = GetFileSize( file_handle, NULL );
+	return (os_uint64_t)file_size;
 }
 
 os_status_t os_file_sync(

--- a/src/os_win.h
+++ b/src/os_win.h
@@ -47,17 +47,17 @@ typedef USHORT in_port_t;
 #define OS_FILE_LINE_BREAK             "\r\n"
 /**
  * @brief Seek from start of file
- * @see os_file_fseek
+ * @see os_file_seek
  */
 #define OS_FILE_SEEK_START             FILE_BEGIN
 /**
  * @brief Seek from current position in file
- * @see os_file_fseek
+ * @see os_file_seek
  */
 #define OS_FILE_SEEK_CURRENT           FILE_CURRENT
 /**
  * @brief Seek from end of file
- * @see os_file_fseek
+ * @see os_file_seek
  */
 #define OS_FILE_SEEK_END               FILE_END
 /**
@@ -458,6 +458,24 @@ OS_API char *os_file_gets(
 );
 
 /**
+ * @brief Write bytes from an array into a file stream
+ *
+ * @note Stops writing when encountering a null terminator
+ * @note Does not write the null terminator to the stream
+ *
+ * @param[in]      str                 Pointer to array to write from
+ * @param[in,out]  stream              Pointer to file to write to
+ *
+ * @return         Number of bytes written
+ *
+ * @see os_file_fgets
+ */
+OS_API size_t os_file_puts(
+	char *str,
+	os_file_t stream
+);
+
+/**
  * @brief Read bytes from a file into an array
  *
  * @note Stops when encountering max read, EOF, or null terminator
@@ -477,20 +495,17 @@ OS_API size_t os_file_read(
 );
 
 /**
- * @brief Write bytes from an array into a file stream
+ * @brief Returns the current position in a file stream
  *
- * @note Stops writing when encountering a null terminator
- * @note Does not write the null terminator to the stream
+ * @param[in,out]  stream              stream to pointer of open file
  *
- * @param[in]      str                 Pointer to array to write from
- * @param[in,out]  stream              Pointer to file to write to
+ * @retval OS_STATUS_BAD_PARAMETER     bad parameter passed to the function
+ * @retval OS_STATUS_FAILURE           failed to move file pointer
+ * @retval OS_STATUS_SUCCESS           on success
  *
- * @return         Number of bytes written
- *
- * @see os_file_fgets
+ * @see os_file_seek
  */
-OS_API size_t os_file_puts(
-	char *str,
+OS_API long int os_file_tell(
 	os_file_t stream
 );
 


### PR DESCRIPTION
These patches are minor fixes to functions for file I/O operations.  They include adding an os_file_tell implementation.  As well as, renaming the "os_file_get_size" and "os_file_get_size_handle" functions to "os_file_size" and "os_file_size_handle", respectfully.