### PR TITLE
os.h.in: make sure PATH_MAX is defined to a non zero value

### DIFF
--- a/src/os.h.in
+++ b/src/os.h.in
@@ -270,7 +270,7 @@ typedef struct os_system_info
  * @brief Maximum path length
  */
 #ifndef PATH_MAX
-#	define PATH_MAX 0
+#	define PATH_MAX 4096
 #endif
 
 


### PR DESCRIPTION
PATH_MAX is used throughout the project.  On Ubuntu PATH_MAX is not
set, so the os.h was setting it to 0, which caused strange errors.

Signed-off-by: Paul Barrette <paulbarrette@gmail.com>