### PR TITLE
os.h.in: correct fix for PATH_MAX is 0 definition

### DIFF
--- a/src/os.h.in
+++ b/src/os.h.in
@@ -270,7 +270,7 @@ typedef struct os_system_info
  * @brief Maximum path length
  */
 #ifndef PATH_MAX
-#	define PATH_MAX 4096
+#	define PATH_MAX 0
 #endif
 
 

--- a/src/os_posix.h
+++ b/src/os_posix.h
@@ -13,6 +13,7 @@
 #endif
 
 #include <stdarg.h> /* for: va_list */
+#include <limits.h> /* for: PATH_MAX definition */
 #include <stdio.h> /* for: FILE *, feof, fgets, fread, fputs, fwrite, fprintf, printf, snprintf, vfprintf */
 #include <signal.h> /* for SIGINT, ... */
 


### PR DESCRIPTION
A previous commit was hard-coding PATH_MAX to a non-zero value.  This is
not correct, as 0 would be expected on systems without a file system.
The correct solution is to include the <limits.h> header file that
defines this value.

Signed-off-by: Keith Holman <keith.holman@windriver.com>