### PR TITLE
Build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+cmake_install.cmake
 CMakeCache.txt
 CMakeDoxyfile.in
 CMakeDoxygenDefaults.cmake
@@ -6,7 +7,7 @@ CMakeFiles/
 CMakeScripts/
 CPackConfig.cmake
 CPackSourceConfig.cmake
-cmake_install.cmake
+CTestTestfile.cmake
 DerivedData/
 Doxyfile
 footer.html
@@ -14,6 +15,7 @@ install_manifest.txt
 Makefile
 os.h
 out/
+test-case-count.py
 *.a
 *.gch
 *.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+# Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,8 +44,20 @@ if( APPLE )
 endif( APPLE )
 
 ### Build Library ###
-option( OSAL_THREAD_SUPPORT "enable multi-thread support" ON )
-option( OSAL_WRAP "provide wrappers for simple functions, this is useful for mocking and unit testing" OFF )
+# Similiar to the cmake "option" command, except that it ensures that the
+# given variable has a value defined and is not defined to "blank"
+# Arguments:
+#   VAR_NAME - name of the variable
+#   VAR_DESCRIPTION - description of the variable
+#   ... - initial value for th eoption (ON or OFF)
+function( OPTION_ENSURE_SET VAR_NAME VAR_DESCRIPTION )
+	if ( DEFINED ${VAR_NAME} AND "x${${VAR_NAME}}" STREQUAL "x" )
+		unset( ${VAR_NAME} CACHE )
+	endif ( DEFINED ${VAR_NAME} AND "x${${VAR_NAME}}" STREQUAL "x" )
+	option( ${ARGV} )
+endfunction( OPTION_ENSURE_SET )
+option_ensure_set( OSAL_THREAD_SUPPORT "enable multi-thread support" ON )
+option_ensure_set( OSAL_WRAP "provide wrappers for simple functions, this is useful for mocking and unit testing" OFF )
 
 # Definitions for build
 #######################


### PR DESCRIPTION
this patch set provides 2 fixes.  First, it fixes the build to work when option is specified on the command line without a value, when a value of ON or OFF is required.  Secondly, it updates .gitignore with more files that are generated during an in-place build.