### PR TITLE
Printf return value fix

### DIFF
--- a/src/os.h.in
+++ b/src/os.h.in
@@ -975,19 +975,25 @@ OS_API char *os_strtok(
  * @note Enviroment variables in the source string are in the format as defined
  *       by the operating system (i.e. for Windows: %VAR%; for POSIX: $VAR )
  *
- * @param[in]      src                 source string (containing environment
+ * @param[in,out]  src                 source string (containing environment
  *                                     variable as defined by the operating
  *                                     system)
- * @param[in]      len                 buffer size
+ * @param[in]      in_len              input buffer size (0 if null-terminated)
+ * @param[in]      out_len             output buffer size
+ *                                     (will be null-terminated, 0 if wanting to
+ *                                     know output size)
  *
- * @return the size of the output string (0 if either src is NULL) or
- * required size if too small
+ * @retval 0       if src is NULL or the input length is > the output length
+ * @retval >0      the size of the output string not including the
+ *                 null-terminating character (or the required size if:
+ *                 out_len == 0)
  *
  * @see os_env_get
  */
 OS_API size_t os_env_expand(
 	char *src,
-	size_t len
+	size_t in_len,
+	size_t out_len
 );
 
 /**

--- a/src/os.h.in
+++ b/src/os.h.in
@@ -1028,7 +1028,9 @@ OS_API size_t os_env_get(
  * @param[in]      format              string format
  * @param[in]      ...                 items to replace based on @p format
  *
- * @return the number of characters printed including the null-terminator
+ * @retval >=0 the number of characters printed not including the
+ *             null-terminator
+ * @retval <0  an error occurred
  *
  * @see os_snprintf
  */
@@ -1037,6 +1039,28 @@ OS_API int os_sprintf(
 	const char *format,
 	...
 ) __attribute__((format(printf,2,3)));
+
+/**
+ * @brief Writes output to a string with a maximum size
+ *
+ * @param[out]     str                 string to output to
+ * @param[in]      size                maximum size of buffer
+ * @param[in]      format              string format
+ * @param[in]      ...                 items to replace based on @p format
+ *
+ * @retval >=0     the number of characters printed not including the
+ *                 null-terminator
+ * @retval -1      an error occurred or the buffer is too small
+ *
+ * @see os_sprintf
+ * @see os_vsnprintf
+ */
+OS_API int os_snprintf(
+	char *str,
+	size_t size,
+	const char *format,
+	...
+) __attribute__((format(printf,3,4)));
 
 /**
  * @brief Flushes a stream to ensure a buffer is transmitted

--- a/src/os_posix.c
+++ b/src/os_posix.c
@@ -1296,6 +1296,7 @@ int os_printf(
 	va_end( args );
 	return result;
 }
+#endif /* if defined(OSAL_WRAP) && OSAL_WRAP */
 
 int os_snprintf(
 	char *str,
@@ -1306,11 +1307,19 @@ int os_snprintf(
 	int result;
 	va_list args;
 	va_start( args, format );
-	result = os_vsnprintf( str, size, format, args );
+#if defined( __APPLE__ )
+	if ( !format )
+		result = -1;
+	else
+#endif /* if defined( __APPLE__ ) */
+		result = os_vsnprintf( str, size, format, args );
+	if ( result < 0 || (size_t)result > size )
+		result = -1;
 	va_end( args );
 	return result;
 }
 
+#if defined(OSAL_WRAP) && OSAL_WRAP
 int os_vfprintf(
 	os_file_t stream,
 	const char *format,
@@ -1318,7 +1327,7 @@ int os_vfprintf(
 {
 	return vfprintf( stream, format, args );
 }
-#endif /* if defined( OSAL_WRAP ) */
+#endif /* if defined(OSAL_WRAP) && OSAL_WRAP */
 
 int os_vsnprintf(
 	char *str,
@@ -1327,8 +1336,6 @@ int os_vsnprintf(
 	va_list args )
 {
 	int result = vsnprintf( str, size, format, args );
-	if ( (size_t)result >= size )
-		result = -1;
 	return result;
 }
 

--- a/src/os_posix.h
+++ b/src/os_posix.h
@@ -646,31 +646,6 @@ OS_API int os_printf(
 #endif
 
 /**
- * @brief Writes output to a string with a maximum size
- *
- * @param[out]     str                 string to output to
- * @param[in]      size                maximum size of buffer
- * @param[in]      format              string format
- * @param[in]      ...                 items to replace based on @p format
- *
- * @return the number of characters printed including the null-terminator,
- *         if the output is truncated then the return value -1
- *
- * @see os_sprintf
- * @see os_vsnprintf
- */
-#if !OSAL_WRAP
-#define os_snprintf                    snprintf
-#else
-OS_API int os_snprintf(
-	char *str,
-	size_t size,
-	const char *format,
-	...
-) __attribute__((format(printf,3,4)));
-#endif
-
-/**
  * @brief Writes output to an open file stream using a va_list
  *
  * @param[in]      stream              stream to write to

--- a/src/os_win.c
+++ b/src/os_win.c
@@ -1623,7 +1623,7 @@ int os_vsnprintf(
 {
 	int result = -1;
 	char *str_end = NULL;
-	if ( StringCchVPrintfEx( str, size, &str_end, NULL, 0, format, args ) ==
+	if ( StringCchVPrintfExA( str, size, &str_end, NULL, 0, format, args ) ==
 		S_OK )
 		result = str_end - str;
 	return result;

--- a/src/os_win.h
+++ b/src/os_win.h
@@ -378,7 +378,8 @@ OS_API int os_fprintf(
 	os_file_t stream,
 	const char *format,
 	...
-) __attribute__((format(printf,2,3)));
+);
+
 /**
  * @brief Writes output to standard out
  *
@@ -393,27 +394,8 @@ OS_API int os_fprintf(
 OS_API int os_printf(
 	const char *format,
 	...
-) __attribute__((format(printf,1,2)));
-/**
- * @brief Writes output to a string with a maximum size
- *
- * @param[out]     str                 string to output to
- * @param[in]      size                maximum size of buffer
- * @param[in]      format              string format
- * @param[in]      ...                 items to replace based on @p format
- *
- * @return the number of characters printed including the null-terminator,
- *         if the output is truncated then the return value -1
- *
- * @see os_sprintf
- * @see os_vsnprintf
- */
-OS_API int os_snprintf(
-	char *str,
-	size_t size,
-	const char *format,
-	...
-) __attribute__((format(printf,3,4)));
+);
+
 /**
  * @brief Writes output to an open file stream using a va_list
  *
@@ -432,7 +414,8 @@ OS_API int os_vfprintf(
 	os_file_t stream,
 	const char *format,
 	va_list args
-) __attribute__((format(printf,2,0)));
+);
+
 /**
  * @brief Writes output to a string with a maximum size using a va_list
  *
@@ -452,7 +435,7 @@ OS_API int os_vsnprintf(
 	size_t size,
 	const char *format,
 	va_list args
-) __attribute__((format(printf,3,0)));
+);
 
 /**
  * @brief Read bytes from a file into a char array

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+# Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 #
 
 set( TESTS
+	"env"
 	"time"
 )
 
@@ -21,6 +22,10 @@ add_definitions( "-DOSAL_STATIC=1" )
 set( OS_LIB ${TARGET}${TARGET_STATIC_SUFFIX} )
 
 include_directories( "${CMAKE_BINARY_DIR}/out" )
+
+# env test
+set( TEST_ENV_SRCS "env_test.c" )
+set( TEST_ENV_LIBS ${OS_LIB} )
 
 # time test
 set( TEST_TIME_SRCS "time_test.c" )

--- a/test/integration/env_test.c
+++ b/test/integration/env_test.c
@@ -1,0 +1,200 @@
+/**
+ * @file
+ * @brief source file containing integration tests for enviroment variable
+ *        functions
+ *
+ * @copyright Copyright (C) 2018 Wind River Systems, Inc. All Rights Reserved.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied."
+ */
+
+#include <os.h>
+
+#include "test_support.h"
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h> /* for SetEnvironmentVariable() function */
+#else /* ifdef _WIN32 */
+#include <stdlib.h> /* for setenv(), unsetenv() functions */
+#endif /* else ifdef _WIN32 */
+#include <string.h> /* for strlen() */
+
+/* test os_env_expand */
+static void test_os_env_expand( void **state )
+{
+	/* size_t os_env_expand( char *src, size_t in_len, size_t out_len ); */
+	char buffer[1024u];
+	size_t i;
+	char out[1024u];
+	size_t result;
+	char var[3u][5u];
+	char value[3u][10u];
+
+	for ( i = 0u; i < 3u; ++i )
+	{
+		snprintf( &var[i][0u], 5u, "VAR%u", (unsigned int)(i+1u) );
+		test_generate_random_string( &value[i][0u], 10u );
+#ifdef _WIN32
+		SetEnvironmentVariableA( &var[i][0u], &value[i][0u] );
+#else /* ifdef _WIN32 */
+		setenv( &var[i][0u], &value[i][0u], 1 );
+#endif /* else ifdef _WIN32 */
+	}
+
+	/* null string */
+	result = os_env_expand( NULL, sizeof(buffer), sizeof(buffer) );
+	assert_int_equal( result, 0u );
+
+	/* obtain output size only */
+#ifdef _WIN32
+	strncpy( buffer, "%VAR1%%VAR2%%VAR3%", sizeof( buffer ) );
+#else /* ifdef _WIN32 */
+	strncpy( buffer, "$VAR1$VAR2$VAR3", sizeof( buffer ) );
+#endif /* else ifdef _WIN32 */
+	snprintf( out, sizeof(out), "%s%s%s",
+		&value[0u][0u], &value[1u][0u], &value[2u][0u] );
+	result = os_env_expand( buffer, 0u, 0u );
+	assert_int_equal( result, strlen(out) );
+
+	/* just variables */
+#ifdef _WIN32
+	strncpy( buffer, "%VAR1%%VAR2%%VAR3%", sizeof( buffer ) );
+#else /* ifdef _WIN32 */
+	strncpy( buffer, "$VAR1$VAR2$VAR3", sizeof( buffer ) );
+#endif /* else ifdef _WIN32 */
+	snprintf( out, sizeof(out), "%s%s%s",
+		&value[0u][0u], &value[1u][0u], &value[2u][0u] );
+	result = os_env_expand( buffer, sizeof(buffer) / 2u, sizeof(buffer) - 3u);
+	assert_int_equal( result, strlen(out) );
+	assert_string_equal( buffer, out );
+
+	/* variables & text */
+#ifdef _WIN32
+	strncpy( buffer, "first: %VAR1%, second: %VAR2%, third: %VAR3%",
+		sizeof( buffer ) );
+#else /* ifdef _WIN32 */
+	strncpy( buffer, "first: $VAR1, second: $VAR2, third: $VAR3",
+		sizeof( buffer ) );
+#endif /* else ifdef _WIN32 */
+	snprintf( out, sizeof(out), "first: %s, second: %s, third: %s",
+		&value[0u][0u], &value[1u][0u], &value[2u][0u] );
+	result = os_env_expand( buffer, sizeof(buffer), sizeof(buffer) );
+	assert_int_equal( result, strlen(out) );
+	assert_string_equal( buffer, out );
+
+	/* in > out */
+#ifdef _WIN32
+	strncpy( buffer, "first: %VAR1%, second: %VAR2%, third: %VAR3%",
+		sizeof( buffer ) );
+#else /* ifdef _WIN32 */
+	strncpy( buffer, "first: $VAR1, second: $VAR2, third: $VAR3",
+		sizeof( buffer ) );
+#endif /* else ifdef _WIN32 */
+	result = os_env_expand( buffer, sizeof(buffer), 25u );
+	assert_int_equal( result, 0u );
+
+	/* var not found */
+#ifdef _WIN32
+	strncpy( buffer, "first: %VAR1%, second: %BAD_VAR_HERE%, third: %VAR3%",
+		sizeof( buffer ) );
+	snprintf( out, sizeof(out), "first: %s, second: %%BAD_VAR_HERE%%, third: %s",
+		&value[0u][0u], &value[2u][0u] );
+#else /* ifdef _WIN32 */
+	strncpy( buffer, "first: $VAR1, second: $BAD_VAR_HERE, third: $VAR3",
+		sizeof( buffer ) );
+	snprintf( out, sizeof(out), "first: %s, second: $BAD_VAR_HERE, third: %s",
+		&value[0u][0u], &value[2u][0u] );
+#endif /* else ifdef _WIN32 */
+	result = os_env_expand( buffer, sizeof(buffer), sizeof(buffer) );
+	assert_int_equal( result, strlen(out) );
+	assert_string_equal( buffer, out );
+
+	/* clean up */
+	for ( i = 0u; i < 3u; ++i )
+	{
+#ifdef _WIN32
+		SetEnvironmentVariableA( &var[i][0u], NULL );
+#else /* ifdef _WIN32 */
+		unsetenv( &var[i][0u] );
+#endif /* else ifdef _WIN32 */
+	}
+}
+
+/* test os_env_get */
+static void test_os_env_get( void **state )
+{
+	/* size_t os_env_get( const char *env, char *dest, size_t len ); */
+	char buffer[1024u];
+	size_t result;
+
+	const char *env_var = "TEST_VAR";
+	const char *env_value = "a really long environment variable value";
+	const size_t env_value_len = strlen( env_value );
+#ifdef _WIN32
+		SetEnvironmentVariableA( env_var, env_value );
+#else /* ifdef _WIN32 */
+		setenv( env_var, env_value, 1 );
+#endif /* else ifdef _WIN32 */
+
+	/* null variable */
+	result = os_env_get( NULL, buffer, sizeof(buffer) );
+	assert_int_equal( result, 0u );
+
+	/* 0 buffer */
+	result = os_env_get( env_var, buffer, 0u );
+	assert_int_equal( result, 0u );
+
+	/* enough space */
+	assert_true( sizeof(buffer) > env_value_len );
+	result = os_env_get( env_var, buffer, sizeof(buffer) );
+	assert_int_equal( result, env_value_len );
+	assert_string_equal( buffer, env_value );
+
+	/* don't write past buffer */
+	strncpy( &buffer[env_value_len], "DONTWRITEHERE", 14 );
+	result = os_env_get( env_var, buffer, env_value_len );
+	assert_int_equal( result, env_value_len );
+	assert_string_equal( &buffer[env_value_len], "DONTWRITEHERE" );
+
+	/* 1 past buffer */
+	strncpy( &buffer[env_value_len], "DONTWRITEHERE", 14 );
+	result = os_env_get( env_var, buffer, env_value_len + 1u );
+	assert_int_equal( result, env_value_len );
+	assert_int_equal( buffer[env_value_len], '\0' );
+	assert_string_equal( &buffer[env_value_len + 1u], "ONTWRITEHERE" );
+
+	/* environment variable not found */
+	result = os_env_get( "AFDAFafdadfa232424234", buffer, sizeof(buffer));
+	assert_int_equal( result, 0u );
+
+	/* clean up */
+#ifdef _WIN32
+		SetEnvironmentVariableA( env_var, NULL );
+#else /* ifdef _WIN32 */
+		unsetenv( env_var );
+#endif /* else ifdef _WIN32 */
+}
+
+int main( int argc, char *argv[] )
+{
+	int result;
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test( test_os_env_expand ),
+		cmocka_unit_test( test_os_env_get ),
+	};
+
+	test_initialize( argc, argv );
+	result = cmocka_run_group_tests( tests, NULL, NULL );
+	test_finalize( argc, argv );
+	return result;
+}
+

--- a/test/test-support/test_support.c
+++ b/test/test-support/test_support.c
@@ -2,7 +2,7 @@
  * @file
  * @brief Source file for common test support functions
  *
- * @copyright Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ int MOCK_SYSTEM_ENABLED = 0;
 
 void test_initialize( int argc, char **argv )
 {
+	srand( (unsigned int)( time( NULL ) ) );
 	MOCK_SYSTEM_ENABLED = 1;
 }
 
@@ -53,7 +54,6 @@ void test_generate_random_string( char *dest, size_t len )
 
 		/* obtain random character */
 		cur_pos = dest;
-		srand( (unsigned int)( ( size_t )( time( NULL ) ) * len ) );
 		for ( i = 0; i < len - 1u; ++i )
 		{
 			*cur_pos = random_chars[(size_t)rand() % random_chars_len];

--- a/test/unit/src/CMakeLists.txt
+++ b/test/unit/src/CMakeLists.txt
@@ -15,6 +15,7 @@
 set( TARGET "os" )
 set( TESTS
 	"char"
+	"printf"
 )
 
 # Remove some compiler warnings for clang
@@ -43,6 +44,11 @@ set( TEST_CHAR_MOCK ${MOCK_API_PART} ${MOCK_OSAL_FUNC} )
 set( TEST_CHAR_SRCS ${MOCK_API_SRCS} ${MOCK_OSAL_SRCS} "char_test.c" )
 set( TEST_CHAR_LIBS ${MOCK_API_LIBS} ${MOCK_OSAL_LIBS} ${OS_LIBS} )
 set( TEST_CHAR_UNIT ${OS_SRC} "os.c" )
+
+set( TEST_PRINTF_MOCK ${MOCK_API_PART} ${MOCK_OSAL_FUNC} )
+set( TEST_PRINTF_SRCS ${MOCK_API_SRCS} ${MOCK_OSAL_SRCS} "printf_test.c" )
+set( TEST_PRINTF_LIBS ${MOCK_API_LIBS} ${MOCK_OSAL_LIBS} ${OS_LIBS} )
+set( TEST_PRINTF_UNIT ${OS_SRC} "os.c" )
 
 add_unit_tests( ${TARGET} ${TESTS} )
 

--- a/test/unit/src/char_test.c
+++ b/test/unit/src/char_test.c
@@ -1,8 +1,8 @@
 /**
  * @file
- * @brief unit testing for IoT library (action source file)
+ * @brief unit testing for OSAL library (character related functions)
  *
- * @copyright Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/src/printf_test.c
+++ b/test/unit/src/printf_test.c
@@ -1,0 +1,80 @@
+/**
+ * @file
+ * @brief unit testing for OSAL library (printf related functions)
+ *
+ * @copyright Copyright (C) 2018 Wind River Systems, Inc. All Rights Reserved.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied."
+ */
+
+#include <os.h>
+#include "test_support.h"
+
+static void test_printf( void **state )
+{
+	/** @todo implement this with mocking */
+}
+
+static void test_fprintf( void **state )
+{
+	/** @todo implement this with mocking */
+}
+
+static void test_snprintf( void **state )
+{
+	char buf[512u];
+	int result;
+
+	result = os_snprintf( NULL, 0u, NULL );
+	assert_int_equal( result, -1 );
+
+	result = os_snprintf( NULL, 0u, "this is a test" );
+	assert_int_equal( result, -1 );
+
+	result = os_snprintf( buf, sizeof(buf), "replacement %s", "test" );
+	assert_int_equal( result, 16 );
+	assert_string_equal( buf, "replacement test" );
+
+	result = os_snprintf( buf, 10, "replacement %s", "test" );
+	assert_int_equal( result, -1 );
+	assert_string_equal( buf, "replaceme" );
+
+	result = os_snprintf( buf, 10, "%u != %d", 1u, -2 );
+	assert_int_equal( result, 7 );
+	assert_string_equal( buf, "1 != -2" );
+}
+
+static void test_vfprintf( void **state )
+{
+	/** @todo implement this with mocking */
+}
+
+static void test_vsnprintf( void **state )
+{
+	/** @todo implement this with mocking */
+}
+
+int main( int argc, char *argv[] )
+{
+	int result;
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test( test_printf ),
+		cmocka_unit_test( test_fprintf ),
+		cmocka_unit_test( test_snprintf ),
+		cmocka_unit_test( test_vfprintf ),
+		cmocka_unit_test( test_vsnprintf ),
+	};
+
+	test_initialize( argc, argv );
+	result = cmocka_run_group_tests( tests, NULL, NULL );
+	test_finalize( argc, argv );
+	return result;
+}


### PR DESCRIPTION
this patch set contains 2 fixes...

1. First, it changes the environment variable functions to handle max length for better security.
2. Secondly, it fixes `os_snprintf` function to return the size required of a string if a given length is too small.