### PR TITLE
ubuntu: PATH_MAX is zero on ubuntu

### DIFF
--- a/src/os.h.in
+++ b/src/os.h.in
@@ -274,7 +274,7 @@ typedef struct os_system_info
  * @brief Maximum path length
  */
 #ifndef PATH_MAX
-#	define PATH_MAX 0
+#	error PATH_MAX is undefined, your operating system is mis-configured or unsupported
 #endif
 
 

--- a/src/os_win.h
+++ b/src/os_win.h
@@ -16,10 +16,9 @@
  */
 
 /** @brief Don't support advanced Windows kernel calls */
-#define WIN32_LEAN_AND_MEAN
 #pragma warning( push, 1 )
+#	define WIN32_LEAN_AND_MEAN
 #	include <Windows.h>
-
 #	include <rpc.h>        /* for uuid functions */
 	/** @brief Universally unique id type */
 	typedef struct _GUID os_uuid_t;


### PR DESCRIPTION
fixes: #19

The correct header files are being included to compile the library on
Ubuntu.  This issue is being raised by a mis-configured system.  Now, an
error will be generated detecting this condition.

Signed-off-by: Keith Holman <keith.holman@windriver.com>