### PR TITLE
posix, win: fix the handling of network adaptors

### DIFF
--- a/src/os.h.in
+++ b/src/os.h.in
@@ -236,6 +236,20 @@ typedef struct
 /** @brief maximum length for a field in system info structure */
 #define OS_SYSTEM_INFO_MAX_LEN 64u
 
+/** @brief Enumeration holding types of address families */
+enum os_address_family
+{
+	OS_FAMILY_UNSPEC = 0,      /**< unspecified */
+	OS_FAMILY_IPV4,            /**< IPv4 address */
+	OS_FAMILY_IPV6             /**< IPv6 address */
+};
+
+typedef enum os_address_family os_address_family_t;
+/** @brief Type for a network adapter */
+typedef struct os_adapter os_adapter_t;
+/** @brief Type for an address of a network adapter */
+typedef struct os_adapter_address os_adapter_address_t;
+
 /** @brief Type for a list of adapters */
 typedef struct os_adapters os_adapters_t;
 
@@ -277,93 +291,132 @@ typedef struct os_system_info
 #	error PATH_MAX is undefined, your operating system is mis-configured or unsupported
 #endif
 
-
-/* adapter information (for obtaining MAC addresses) */
+/* adapter address information */
 /**
  * @brief Get general information of the current adapter in the the list
  *
- * @param[in,out]  adapters            adapter list to retrieve information from
- * @param[out]     family              family the adapter belongs to
- * @param[out]     flags               flags set on the adapter
- * @param[out]     address             buffer to fill with the address
+ * @param[in,out]  address             adapter address to retrieve information
+ * @param[out]     index               index of the adapter (optional)
+ * @param[out]     family              family the adapter belongs to (optional)
+ * @param[out]     address_out         buffer to fill with the address (optional)
  * @param[in]      address_len         size of the address buffer
  *
  * @retval OS_STATUS_BAD_PARAMETER     invalid parameter passed to the function
- * @retval OS_STATUS_FAILURE           system error
  * @retval OS_STATUS_SUCCESS           on success
+ * @retval OS_STATUS_NOT_FOUND         at end of list
  *
  * @see os_adapters_next
  * @see os_adapters_obtain
  * @see os_adapters_release
+ * @see os_adapters_address_first
+ * @see os_adapters_address_next
  */
 OS_API os_status_t os_adapters_address(
-	os_adapters_t *adapters,
-	int *family,
-	int *flags,
-	char *address,
+	os_adapter_address_t *address,
+	unsigned int *index,
+	os_address_family_t *family,
+	char *address_out,
 	size_t address_len
 );
 
 /**
- * @brief Get the index of the current adapter in the the list
+ * @brief Returns a pointer to the first address for a network adapter
  *
- * @param[in,out]  adapters            adapter list to retrieve information from
- * @param[out]     index               index of the adapter
+ * @param[in]      adapter             adapter to get first address for
+ * @param[out]     address             address for the adapter
  *
  * @retval OS_STATUS_BAD_PARAMETER     invalid parameter passed to the function
- * @retval OS_STATUS_FAILURE           system error
  * @retval OS_STATUS_SUCCESS           on success
+ * @retval OS_STATUS_NOT_FOUND         no addresses associated with adapter 
  *
- * @see os_adapters_next
- * @see os_adapters_obtain
- * @see os_adapters_release
+ * @see os_adapters_address
+ * @see os_adapters_address_next
  */
-OS_API os_status_t os_adapters_index(
-	os_adapters_t *adapters,
-	unsigned int *index
+OS_API os_status_t os_adapters_address_first(
+	const os_adapter_t *adapter,
+	os_adapter_address_t *address
 );
 
 /**
+ * @brief Returns a pointer to the next address for a network adapter
+ *
+ * @param[in,out]  address             in: current address; out: next address
+ *
+ * @retval OS_STATUS_BAD_PARAMETER     invalid parameter passed to the function
+ * @retval OS_STATUS_SUCCESS           on success
+ * @retval OS_STATUS_NOT_FOUND         no more addresses associated with adapter
+ *
+ * @see os_adapters_address
+ * @see os_adapters_address_first
+ */
+OS_API os_status_t os_adapters_address_next(
+	os_adapter_address_t *address
+);
+
+/* adapter information */
+/**
  * @brief Get the mac address of the current adapter in the list
  *
- * @param[in,out]  adapters            adapter list to retrieve information from
+ * @param[in,out]  adapter             adapter list to retrieve information from
  * @param[out]     mac                 buffer to fill with the mac address
  * @param[in]      mac_len             size of the buffer
  *
  * @retval OS_STATUS_BAD_PARAMETER     invalid parameter passed to the function
- * @retval OS_STATUS_FAILURE           system error
+ * @retval OS_STATUS_NOT_FOUND         no valid mac address found
  * @retval OS_STATUS_SUCCESS           on success
  *
+ * @see os_adapters_name
  * @see os_adapters_next
  * @see os_adapters_obtain
  * @see os_adapters_release
  */
 OS_API os_status_t os_adapters_mac(
-	os_adapters_t *adapters,
+	const os_adapter_t *adapter,
 	char *mac,
 	size_t mac_len
 );
 
 /**
- * @brief Moves to the next adapter in the list
+ * @brief Get the name of the current adapter in the list
  *
- * @param[in,out]  adapters            adapter list to iterate
+ * @param[in,out]  adapter             adapter list to retrieve information from
+ * @param[out]     name                buffer to fill with the name
+ * @param[in]      name_len            size of the buffer
  *
  * @retval OS_STATUS_BAD_PARAMETER     invalid parameter passed to the function
- * @retval OS_STATUS_FAILURE           system error
+ * @retval OS_STATUS_SUCCESS           on success
+ *
+ * @see os_adapters_mac
+ * @see os_adapters_next
+ * @see os_adapters_obtain
+ * @see os_adapters_release
+ */
+OS_API os_status_t os_adapters_name(
+	const os_adapter_t *adapter,
+	char *name,
+	size_t name_len
+);
+
+/**
+ * @brief Moves to the next adapter in the list
+ *
+ * @param[in,out]  adapter             adapter list to iterate
+ *
+ * @retval OS_STATUS_BAD_PARAMETER     invalid parameter passed to the function
+ * @retval OS_STATUS_NOT_FOUND         no more network adapters
  * @retval OS_STATUS_SUCCESS           on success
  *
  * @see os_adapters_obtain
  * @see os_adapters_release
  */
 OS_API os_status_t os_adapters_next(
-	os_adapters_t *adapters
+	os_adapter_t *adapter
 );
 
 /**
  * @brief Obtains the list of adapters connected to the system
  *
- * @param[out]     adapters            list of adapters
+ * @param[in,out]  adapter             list of adapters
  *
  * @retval OS_STATUS_BAD_PARAMETER     invalid parameter passed to the function
  * @retval OS_STATUS_FAILURE           system error
@@ -374,23 +427,22 @@ OS_API os_status_t os_adapters_next(
  * @see os_adapters_release
  */
 OS_API os_status_t os_adapters_obtain(
-	os_adapters_t **adapters
+	os_adapter_t *adapter
 );
 
 /**
  * @brief Release memory allocated for the adapters
  *
- * @param[in,out]  adapters            adapter list to release
+ * @param[in,out]  adapter             adapter list to release
  *
  * @retval OS_STATUS_BAD_PARAMETER     invalid parameter passed to the function
- * @retval OS_STATUS_FAILURE           system error
  * @retval OS_STATUS_SUCCESS           on success
  *
  * @see os_adapters_next
  * @see os_adapters_obtain
  */
 OS_API os_status_t os_adapters_release(
-	os_adapters_t *adapters
+	os_adapter_t *adapter
 );
 
 /* character testing support */

--- a/src/os_posix.h
+++ b/src/os_posix.h
@@ -34,6 +34,19 @@
 #include <stdio.h> /* for: FILE *, feof, fgets, fread, fputs, fwrite, fprintf, printf, snprintf, vfprintf */
 #include <signal.h> /* for SIGINT, ... */
 
+/** @brief Structure representing a network adapter address */
+struct os_adapter_address
+{
+	struct ifaddrs *cur;        /**< current address */
+};
+
+/** @brief Structure representing a network adapter */
+struct os_adapter
+{
+	struct ifaddrs *first;      /**< first network adapter */
+	struct ifaddrs *cur;        /**< current network adapter */
+};
+
 /**
  * @brief Handle to an open file
  */

--- a/src/os_win.h
+++ b/src/os_win.h
@@ -19,6 +19,9 @@
 #pragma warning( push, 1 )
 #	define WIN32_LEAN_AND_MEAN
 #	include <Windows.h>
+#	include <Winsock2.h>       /* for socket functions and structures */
+#	include <ws2tcpip.h>       /* for SOCKETADDR_IN6 structure */
+#	include <Iphlpapi.h>       /* for GetAdaptersAddresses */
 #	include <rpc.h>        /* for uuid functions */
 	/** @brief Universally unique id type */
 	typedef struct _GUID os_uuid_t;
@@ -48,6 +51,20 @@
 #endif
 /** @brief Socket port type */
 typedef USHORT in_port_t;
+
+/** @brief Structure representing a network adapter address */
+struct os_adapter_address
+{
+	IP_ADAPTER_ADDRESSES *adapter; /**< adapter */
+	IP_ADAPTER_UNICAST_ADDRESS *cur; /**< current address */
+};
+
+/** @brief Structure representing a network adapter */
+struct os_adapter
+{
+	IP_ADAPTER_ADDRESSES *first; /**< first network adapter */
+	IP_ADAPTER_ADDRESSES *cur;   /**< current network adapter */
+};
 
 /**
  * @brief Directory seperator character

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -13,6 +13,7 @@
 #
 
 set( TESTS
+	"adapters"
 	"env"
 	"time"
 )
@@ -22,6 +23,10 @@ add_definitions( "-DOSAL_STATIC=1" )
 set( OS_LIB ${TARGET}${TARGET_STATIC_SUFFIX} )
 
 include_directories( "${CMAKE_BINARY_DIR}/out" )
+
+# adapters test
+set( TEST_ADAPTERS_SRCS "adapters_test.c" )
+set( TEST_ADAPTERS_LIBS ${OS_LIB} )
 
 # env test
 set( TEST_ENV_SRCS "env_test.c" )

--- a/test/integration/adapters_test.c
+++ b/test/integration/adapters_test.c
@@ -1,0 +1,545 @@
+/**
+ * @file
+ * @brief source file containing integration tests for network adapters
+ *
+ * @copyright Copyright (C) 2018 Wind River Systems, Inc. All Rights Reserved.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied."
+ */
+
+#include <os.h>
+
+#include "test_support.h"
+
+#if defined( _WIN32 )
+#	define WIN32_LEAN_AND_MEAN
+#	include <Windows.h>
+#	include <Winsock2.h>       /* for socket functions and structures */
+#	include <ws2tcpip.h>       /* for SOCKETADDR_IN6 structure */
+#	include <Iphlpapi.h>       /* for GetAdaptersAddresses */
+#	include <Strsafe.h>        /* for StringCbLengthA, StringCbCopyA */
+#else /* if defined( _WIN32 ) */
+#	include <net/if.h>         /* for if_nametoindex */
+#	if defined( __linux__ )
+#		include <linux/if_packet.h> /* for sockaddr_ll */
+#	else
+#		include <net/if_dl.h>       /* for LLADDR definition */
+#	endif /* if defined( __linux__ ) */
+#	include <arpa/inet.h>      /* for inet_ntop */
+#	include <ifaddrs.h>        /* for getifaddrs, freeifaddrs */
+#	include <netinet/in.h>     /* for AF_LINK (apple) */
+#	include <sys/socket.h>     /* for AF_LINK (freebsd) */
+#	include <sys/types.h>      /* for u_char, u_short (freebsd) */
+#endif /* else if defined( _WIN32 ) */
+
+/** @brief structure for information about an ip address */
+struct ip_address
+{
+	int found;                  /**< whether address was found */
+	int is_ipv6;                /**< address is an ipv6 address */
+	char *address;              /**< string representation of the address */
+	struct ip_address *next;    /**< pointer to the next address */
+};
+
+/** @brief structure containing information about a network adapter */
+struct adapter
+{
+	int found;                  /**< whether adapter was found */
+	unsigned int idx;           /**< index of the adapter */
+	unsigned int idx6;          /**< index of the adapter (ipv6) */
+	unsigned int mac_len;       /**< length of the mac address */
+	unsigned char *mac;         /**< mac address */
+	char *name;                 /**< name of the interface */
+	struct ip_address *ip;      /**< pointer to the first assigned ip */
+	struct adapter *next;       /**< pointer to the next adapter */
+};
+
+static void free_adapters( struct adapter *adapter )
+{
+	while ( adapter )
+	{
+		struct adapter *const adapter_next = adapter->next;
+		struct ip_address *ip = adapter->ip;
+
+		if ( adapter->mac ) test_free( adapter->mac );
+		if ( adapter->name ) test_free( adapter->name );
+		while ( ip )
+		{
+			struct ip_address *const ip_next = ip->next;
+			if ( ip->address ) test_free( ip->address );
+			test_free( ip );
+			ip = ip_next;
+		}
+
+		test_free( adapter );
+		adapter = adapter_next;
+	}
+}
+
+static int get_adapters( struct adapter **adapter )
+{
+	int rv = -1;
+	struct adapter *first_adapter = NULL;
+	struct adapter *last_adapter = NULL;
+#if defined(_WIN32)
+	ULONG buf_len = 0u;
+	const ULONG family = AF_UNSPEC;
+	const ULONG flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST |
+		GAA_FLAG_SKIP_DNS_SERVER;
+
+	if ( GetAdaptersAddresses( family, flags,
+		NULL, NULL, &buf_len ) == ERROR_BUFFER_OVERFLOW )
+	{
+		IP_ADAPTER_ADDRESSES *aa =
+			HeapAlloc( GetProcessHeap(), 0, buf_len );
+		if ( aa &&  GetAdaptersAddresses( family, flags,
+			NULL, aa, &buf_len ) == NO_ERROR )
+		{
+			IP_ADAPTER_ADDRESSES *cur_aa = aa;
+			rv = 0;
+			while ( cur_aa )
+			{
+				struct adapter *cur_adapter =
+					test_malloc( sizeof( struct adapter ) );
+				IP_ADAPTER_UNICAST_ADDRESS *cur_address;
+				size_t name_len;
+				size_t fname_len;
+
+				ZeroMemory( cur_adapter,
+					sizeof( struct adapter ) );
+				cur_adapter->idx = cur_aa->IfIndex;
+				cur_adapter->idx6 = cur_aa->Ipv6IfIndex;
+
+				/* mac address */
+				cur_adapter->mac_len =
+					cur_aa->PhysicalAddressLength;
+				if ( cur_aa->PhysicalAddressLength == 0u )
+					cur_adapter->mac_len = 6u;
+
+				cur_adapter->mac = test_malloc(
+					cur_adapter->mac_len );
+				if ( cur_aa->PhysicalAddressLength == 0u )
+					ZeroMemory( cur_adapter->mac,
+						cur_adapter->mac_len );
+				else
+					CopyMemory( cur_adapter->mac,
+						cur_aa->PhysicalAddress,
+						cur_adapter->mac_len );
+
+				/* adapter name */
+				StringCbLengthW( cur_aa->FriendlyName,
+					MAX_ADAPTER_NAME_LENGTH, &fname_len );
+				name_len = WideCharToMultiByte( CP_UTF8, 0,
+					cur_aa->FriendlyName, fname_len,
+					NULL, 0, NULL, NULL );
+				cur_adapter->name = test_malloc(
+					sizeof( char ) * ( name_len + 1u ) );
+				WideCharToMultiByte( CP_UTF8, 0,
+					cur_aa->FriendlyName, fname_len,
+					cur_adapter->name, name_len,
+					NULL, NULL );
+
+				/* assigned ip addresses for interface */
+				cur_address = cur_aa->FirstUnicastAddress;
+				while ( cur_address )
+				{
+					struct ip_address *ip =
+						test_malloc( sizeof( struct ip_address ) );
+					const short af_family =
+						(short)(cur_address->Address.lpSockaddr->sa_family);
+
+					ZeroMemory( ip,
+						sizeof( struct ip_address ) );
+
+					switch (af_family)
+					{
+					case AF_INET:
+						{
+							SOCKADDR_IN *in = (SOCKADDR_IN *)(cur_address->Address.lpSockaddr);
+							ip->address = test_malloc( sizeof( char * ) * ( INET_ADDRSTRLEN + 1u ) );
+							InetNtop(AF_INET, &(in->sin_addr), ip->address, INET_ADDRSTRLEN);
+							break;
+						}
+					case AF_INET6:
+						{
+							SOCKADDR_IN6 *in = (SOCKADDR_IN6 *)(cur_address->Address.lpSockaddr);
+							ip->address = test_malloc( sizeof( char * ) * ( INET6_ADDRSTRLEN + 1u ) );
+							InetNtop(AF_INET6, &(in->sin6_addr), ip->address, INET6_ADDRSTRLEN );
+							ip->is_ipv6 = 1;
+						}
+					}
+
+					/* add to end of list */
+					if ( !cur_adapter->ip )
+						cur_adapter->ip = ip;
+					else
+					{
+						struct ip_address *cur_ip =
+							cur_adapter->ip;
+						struct ip_address *last_ip;
+						do {
+							last_ip = cur_ip;
+							cur_ip = cur_ip->next;
+						} while ( cur_ip );
+						last_ip->next = ip;
+					}
+
+					/* go to next address */
+					cur_address = cur_address->Next;
+				}
+
+				/* add to end of linked list */
+				if ( last_adapter )
+					last_adapter->next = cur_adapter;
+				else
+					first_adapter = cur_adapter;
+				last_adapter = cur_adapter;
+				++rv;
+
+				/* go to next adapter */
+				cur_aa = cur_aa->Next;
+
+			}
+		}
+
+		if ( aa )
+			HeapFree( GetProcessHeap(), 0, aa );
+	}
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+	struct ifaddrs *ifap;
+	if ( getifaddrs( &ifap ) == 0 )
+	{
+		struct ifaddrs *ifa;
+		rv = 0;
+		for ( ifa = ifap; ifa != NULL; ifa = ifa->ifa_next )
+		{
+			struct adapter *cur_adapter = NULL;
+			int family;
+
+			/* find the adapter matching the name */
+			if ( ifa->ifa_name )
+			{
+				cur_adapter = first_adapter;
+				while ( cur_adapter &&
+					os_strcmp( cur_adapter->name, ifa->ifa_name ) != 0 )
+					cur_adapter = cur_adapter->next;
+			}
+
+			/* not adapter matching name, so let's create one */
+			if ( !cur_adapter )
+			{
+				size_t name_len = 0u;
+				cur_adapter =
+					test_malloc( sizeof( struct adapter ) );
+				os_memset( cur_adapter, 0,
+					sizeof( struct adapter ) );
+				if ( ifa->ifa_name )
+				{
+					name_len = os_strlen( ifa->ifa_name );
+					cur_adapter->idx = if_nametoindex( ifa->ifa_name );
+				}
+				else
+					cur_adapter->idx = (unsigned int)(rv + 1);
+
+				cur_adapter->idx6 =cur_adapter->idx;
+				cur_adapter->name = test_malloc( name_len + 1u );
+				os_strncpy( cur_adapter->name, ifa->ifa_name, name_len );
+				cur_adapter->name[name_len] = '\0';
+				++rv;
+
+				/* add to end of linked list */
+				if ( last_adapter )
+					last_adapter->next = cur_adapter;
+				else
+					first_adapter = cur_adapter;
+				last_adapter = cur_adapter;
+			}
+
+			family = ifa->ifa_addr->sa_family;
+			switch ( family )
+			{
+#if defined(__linux__)
+				case AF_PACKET:
+				{
+					const unsigned char *mac;
+					unsigned int mac_len = 6u;
+					const struct sockaddr_ll *s =
+						(const struct sockaddr_ll *)
+						(const void *)ifa->ifa_addr;
+					mac = (const unsigned char *)(s->sll_addr);
+#else /* if defined(__linux__) */
+				case AF_LINK:
+				{
+					const unsigned char *mac;
+					unsigned int mac_len = 6u;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+					mac = (const unsigned char *)
+						LLADDR((const struct sockaddr_dl*)(const void*)ifa->ifa_addr);
+#pragma GCC diagnostic pop
+#endif /* else if defined(__linux__) */
+					/* copy mac address */
+					cur_adapter->mac = test_malloc( mac_len );
+					os_memcpy(cur_adapter->mac, mac, mac_len );
+					cur_adapter->mac_len = mac_len;
+					break;
+				}
+				case AF_INET:
+				case AF_INET6:
+				{
+					struct ip_address *ip = test_malloc( sizeof( struct ip_address ) );
+					os_memset( ip, 0, sizeof( struct ip_address ) );
+					if ( family == AF_INET )
+					{
+						const struct sockaddr_in *const in =
+							(const struct sockaddr_in *)
+							(const void *)ifa->ifa_addr;
+						ip->address = test_malloc( sizeof( char * ) * ( INET_ADDRSTRLEN + 1u ) );
+						inet_ntop(family, &(in->sin_addr), ip->address, INET_ADDRSTRLEN);
+					}
+					else
+					{
+						const struct sockaddr_in6 *const in =
+							(const struct sockaddr_in6 *)
+							(const void *)ifa->ifa_addr;
+						ip->address = test_malloc( sizeof( char * ) * ( INET6_ADDRSTRLEN + 1u ) );
+						inet_ntop(family, &(in->sin6_addr), ip->address, INET6_ADDRSTRLEN );
+						ip->is_ipv6 = 1;
+					}
+
+					/* add to end of list */
+					if ( !cur_adapter->ip )
+						cur_adapter->ip = ip;
+					else
+					{
+						struct ip_address *cur_ip =
+							cur_adapter->ip;
+						struct ip_address *last_ip;
+						do {
+							last_ip = cur_ip;
+							cur_ip = cur_ip->next;
+						} while ( cur_ip );
+						last_ip->next = ip;
+					}
+					break;
+				}
+			}
+		}
+		freeifaddrs( ifap );
+	}
+#else
+	rv = 0; /* no results */
+#endif
+	/* return results */
+	if ( adapter )
+		*adapter = first_adapter;
+	else
+		free_adapters( first_adapter );
+	return rv;
+}
+
+static void print_adapters( struct adapter *adapter )
+{
+	while ( adapter )
+	{
+		struct ip_address *ip = adapter->ip;
+		const char *name = "";
+		if ( adapter->name )
+			name = adapter->name;
+
+		os_printf( "idx : %d\n", adapter->idx );
+		os_printf( "idx6: %d\n", adapter->idx6 );
+		os_printf( "name: %s\n", name );
+		if ( adapter->mac )
+		{
+			unsigned int i;
+			os_printf( "mac : " );
+			for ( i = 0u; i < adapter->mac_len; ++i )
+			{
+				if ( i > 0u )
+					printf( ":" );
+				printf("%02x", adapter->mac[i] & 0xff);
+			}
+			printf("\n");
+		}
+
+		while ( ip )
+		{
+			if ( ip->address && ip->is_ipv6) os_printf( "ipv6: %s\n", ip->address );
+			else if ( ip->address) os_printf( "ipv4: %s\n", ip->address );
+			ip = ip->next;
+		}
+		os_printf("\n");
+		adapter = adapter->next;
+	}
+}
+
+/* test obtaining network addresses of network adapters */
+static void test_os_adapters_address( void **state )
+{
+	struct adapter *adapter = (struct adapter *)*state;
+	os_adapter_t adapters;
+
+	if ( os_adapters_obtain( &adapters ) == OS_STATUS_SUCCESS )
+	{
+		do {
+			struct adapter *ad = adapter;
+			char name[128u] = {0};
+			os_adapters_name( &adapters, name, sizeof(name) );
+
+			while( ad && os_strcmp( ad->name, name ) != 0 )
+				ad = ad->next;
+
+			if ( ad )
+			{
+				os_adapter_address_t address;
+				if ( os_adapters_address_first( &adapters,
+					&address ) == OS_STATUS_SUCCESS )
+				do {
+					struct ip_address *ip;
+					unsigned int idx = 0u;
+					char address_str[128u] = {0};
+					os_address_family_t family =
+						OS_FAMILY_UNSPEC;
+					os_adapters_address( &address, &idx,
+						&family, address_str,
+						sizeof(address_str) );
+
+					ip = ad->ip;
+					/* find matching ip */
+					while ( ip && os_strcmp( ip->address,
+						address_str ) != 0 )
+						ip = ip->next;
+
+					if ( ip )
+						ip->found = 1;
+					else
+					{
+						os_printf( "ERROR: test setup "
+							"failed to find address "
+							"%s (for adapter: %s)\n",
+							address_str, name );
+					}
+					assert_true( ip != NULL );
+				} while ( os_adapters_address_next( &address )
+					== OS_STATUS_SUCCESS );
+			}
+			else
+			{
+				os_printf(
+					"ERROR: test setup failed to find adapter:"
+					" %s\n", name );
+			}
+			assert_true( ad != NULL );
+		} while( os_adapters_next( &adapters ) == OS_STATUS_SUCCESS );
+		os_adapters_release( &adapters );
+	}
+
+	/* check all adapters were found */
+	while ( adapter )
+	{
+		struct ip_address *ip = adapter->ip;
+		while ( ip )
+		{
+			if ( !ip->found )
+			{
+				os_printf( "ERROR: failed to find address (%s) "
+					"for adapter: %s\n",
+					ip->address, adapter->name );
+			}
+			assert_true( ip->found );
+			ip = ip->next;
+		}
+		adapter = adapter->next;
+	}
+}
+
+/* test obtaining mac addresses of network adapters */
+static void test_os_adapters_mac( void **state )
+{
+	struct adapter *adapter = (struct adapter *)*state;
+	os_adapter_t adapters;
+
+	if ( os_adapters_obtain( &adapters ) == OS_STATUS_SUCCESS )
+	{
+		do {
+			struct adapter *ad = adapter;
+			int ad_found = 0;
+			char mac[24u] = {0};
+			char name[128u] = {0};
+			os_adapters_mac( &adapters, mac, sizeof(mac) );
+			os_adapters_name( &adapters, name, sizeof(name) );
+
+			while( ad && !ad_found )
+			{
+				if ( os_strcmp( ad->name, name ) == 0 )
+				{
+					char mac_str[24u] = {0};
+					unsigned int i;
+					ad->found = ad_found = 1;
+					for ( i = 0u; i < ad->mac_len; ++i )
+					{
+						os_snprintf( &mac_str[ i * 3u ], 4,
+							"%2.2x:",
+							ad->mac[ i ] );
+					}
+					mac_str[i * 3u - 1u] = '\0';
+					assert_string_equal( mac, mac_str );
+				}
+				ad = ad->next;
+			}
+
+			if ( !ad_found )
+			{
+				os_printf(
+					"ERROR: test setup failed to find adapter:"
+					" %s [%s]\n", name, mac );
+			}
+			assert_true( ad_found );
+		} while( os_adapters_next( &adapters ) == OS_STATUS_SUCCESS );
+		os_adapters_release( &adapters );
+	}
+
+	/* check all adapters were found */
+	while ( adapter )
+	{
+		if ( !adapter->found )
+		{
+			os_printf( "ERROR: failed to find adapter: %s\n",
+				adapter->name );
+			assert_true( adapter->found );
+		}
+		adapter = adapter->next;
+	}
+}
+
+int main( int argc, char *argv[] )
+{
+	int result;
+	struct adapter *adapters = NULL;
+
+	get_adapters( &adapters );
+	print_adapters( adapters );
+
+	{
+		const struct CMUnitTest tests[] = {
+			cmocka_unit_test_prestate( test_os_adapters_address, adapters ),
+			cmocka_unit_test_prestate( test_os_adapters_mac, adapters ),
+		};
+
+		test_initialize( argc, argv );
+		result = cmocka_run_group_tests( tests, NULL, NULL );
+		test_finalize( argc, argv );
+	}
+	free_adapters( adapters );
+	return result;
+}
+


### PR DESCRIPTION
fixes: #16

This patch contains fixes for how network adapters are determined across
the various platforms.  This patch also includes a test to test across
the platforms.

Signed-off-by: Keith Holman <keith.holman@windriver.com>