### PR TITLE
win: add os_file_eof function

### DIFF
--- a/src/os_win.c
+++ b/src/os_win.c
@@ -854,6 +854,17 @@ os_status_t os_file_delete(
 	return result;
 }
 
+os_bool_t os_file_eof(
+	os_file_t stream )
+{
+	os_bool_t result = OS_FALSE;
+	LARGE_INTEGER pos, size;
+	if ( SetFilePointerEx( stream, 0, &pos, FILE_CURRENT ) &&
+	     GetFileSizeEx( stream, &size ) && (pos.QuadPart >= size.QuadPart) )
+		result = OS_TRUE;
+	return result;
+}
+
 os_bool_t os_file_exists(
 	const char *file_path )
 {

--- a/src/os_win.h
+++ b/src/os_win.h
@@ -467,6 +467,18 @@ OS_API int os_vsnprintf(
 );
 
 /**
+ * @brief check if at end-of-file
+ *
+ * @param[in]      stream              stream to write to
+ *
+ * @retval         OS_FALSE            end of file bit not set
+ * @retval         OS_TRUE             end of file bit is set
+ */
+OS_API os_bool_t os_file_eof(
+	os_file_t stream
+);
+
+/**
  * @brief Read bytes from a file into a char array
  *
  * @note Stops when encountering max read, EOF, or null terminator


### PR DESCRIPTION
This patch adds a function for testing if a stream is at the end of the
file.

Signed-off-by: Keith Holman <keith.holman@windriver.com>