### PR TITLE
os_system_run: take arguments as a structure

### DIFF
--- a/build-sys/cmake/TestSupport.cmake
+++ b/build-sys/cmake/TestSupport.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2017 Wind River Systems, Inc. All Rights Reserved.
+# Copyright (C) 2015-2018 Wind River Systems, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ if ( CMOCKA_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test" )
 		if ( MSVC )
 			get_filename_component( CMOCKA_LIB_DIR
 				"${CMOCKA_LIBRARY}" DIRECTORY )
-			find_file( CMOCKA_DLL "cmocka.dll"
+			find_file( CMOCKA_DLL "${CMAKE_SHARED_LIBRARY_PREFIX}cmocka${CMAKE_SHARED_LIBRARY_SUFFIX}"
 				HINTS "${CMOCKA_LIB_DIR}"
 				      "{CMOCKA_LIB_DIR}/../bin"
 				NO_DEFAULT_PATH
@@ -73,7 +73,7 @@ if ( CMOCKA_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test" )
 				add_custom_command( TARGET "integration-tests"
 					COMMAND ${CMAKE_COMMAND} -E copy_if_different
 						"${CMOCKA_DLL}"
-						"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/cmocka.dll"
+						"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}cmocka${CMAKE_SHARED_LIBRARY_SUFFIX}"
 				)
 			endif( CMOCKA_DLL )
 		endif( MSVC )

--- a/src/os.h.in
+++ b/src/os.h.in
@@ -282,6 +282,115 @@ typedef struct os_system_info
 
 @OS_FUNCTION_DEF@
 
+/** @brief structure for arguments to pass to the @p os_system_run command */
+typedef struct
+{
+	/**
+	 * @brief whether or not to block the parent process to wait for a
+	 *        result
+	 */
+	os_bool_t block;
+
+	/**
+	 * @brief command string to be run
+	 *
+	 * @note one and only one of @p cmd or @p fptr must be defined
+	 */
+	const char *cmd;
+
+	/**
+	 * @brief function pointer to start execution at
+	 *
+	 * @note one and only one of @p cmd or @p fptr must be defined
+	 *
+	 * @note starting a new process by a function pointer isn't supported
+	 *       on every operating system
+	 */
+	int (*fptr)(int argc, char *argv[]);
+
+	/**
+	 * @brief union for output values for blocking and non-blocking
+	 */
+	union opts
+	{
+		/**
+		 * @brief structure containing output buffer for blocking calls
+		 */
+		struct block
+		{
+			/**
+			 * @brief 'standard out' storage buffer information
+			 */
+			struct std_out
+			{
+				/** @brief location to store 'standard out' */
+				char *buf;
+				/** @brief size of 'standard out' buffer */
+				size_t len;
+			} std_out;
+
+			/**
+			 * @brief 'standard error' storage buffer information
+			 */
+			struct std_err
+			{
+				/** @brief location to store 'standard error' */
+				char *buf;
+				/** @brief size of 'standard error' buffer */
+				size_t len;
+			} std_err;
+
+			/**
+			 * @brief maximum amount of time to wait in
+			 *        millisecondds for a process to complete
+			 *        (0 for indefinite)
+			 */
+			os_millisecond_t max_wait_time;
+		} block;
+
+		struct nonblock
+		{
+			/**
+			 * @brief pipe to write 'standard out' when not blocking
+			 */
+			os_file_t std_out;
+			/**
+			 * @brief pipe to write 'standard error' when not
+			 *        blocking
+			 */
+			os_file_t std_err;
+		} nonblock;
+	} opts;
+
+	/**
+	 * @brief process priority (0 to inherit)
+	 */
+	int priority;
+
+	/**
+	 * @brief run command in a privileged mode
+	 *
+	 * Creates the new process as a super user (i.e. "root"
+	 * on linux, "system" in windows, or as a "kernel" task on vxworks)
+	 */
+	os_bool_t privileged;
+
+	/**
+	 * @brief obtain the return code of the process (optional)
+	 */
+	int return_code;
+
+	/**
+	 * @brief process stack size (0 to inherit)
+	 */
+	size_t stack_size;
+
+} os_system_run_args_t;
+
+#define OS_SYSTEM_RUN_ARGS_INIT \
+	{ OS_FALSE, NULL, NULL, { { { NULL, 0u }, { NULL, 0u }, 0u } }, \
+	  0, OS_FALSE, -1, 0u }
+
 /* if there is no file system */
 /**
  * @def PATH_MAX
@@ -1695,59 +1804,16 @@ OS_API os_status_t os_system_info(
 /**
  * @brief run an executable on the operating system asynchronously
  *
- * @param[in]      command             command string to be run
- * @param[out]     exit_status         return code of the executable (optional)
- * @param[in]      privileged          run command in a privileged mode (or as
- *                                     a super user (i.e. "root" on linux,
- *                                     "system" in windows, or as a "kernel"
- *                                     task on vxworks)
- * @param[in]      priority            process priority (0 to inherit)
- * @param[in]      stack_size          process stack size (0 to inherit)
- * @param[in]      pipe_files          files/pipes to write 'standard out' &
- *                                     'standard error' to
+ * @param[in,out]  args                system run arguments
  *
+ * @retval OS_STATUS_BAD_PARAMETER     invalid parameter value passed
  * @retval OS_STATUS_INVOKED           command triggered as a background process
- * @retval OS_STATUS_NOT_EXECUTABLE    the path provided can not be executed
- */
-OS_API os_status_t os_system_run(
-	const char *command,
-	int *exit_status,
-	os_bool_t privileged,
-	int priority,
-	size_t stack_size,
-	os_file_t pipe_files[2u] );
-
-/**
- * @brief run an executable on the operating system and wait for it to complete
- *
- * @param[in]      command             command string to be run
- * @param[out]     exit_status         return code of the executable (optional)
- * @param[in]      privileged          run command in a privileged mode (or as
- *                                     a super user (i.e. "root" on linux,
- *                                     "system" in windows, or as a "kernel"
- *                                     task on vxworks)
- * @param[in]      priority            process priority (0 to inherit)
- * @param[in]      stack_size          process stack size (0 to inherit)
- * @param[out]     out_buf             pointer to buffers to write
- *                                     'standard out' & 'standard error' to
- * @param[in,out]  out_len             size of buffers for 'standard out' and
- *                                     'standard error'
- * @param[in]      max_time_out        maximum amount of time to wait
- *
- * @retval OS_STATUS_IO_ERROR          failed to setup error & output capture io
  * @retval OS_STATUS_NOT_EXECUTABLE    the path provided can not be executed
  * @retval OS_STATUS_SUCCESS           on success
  * @retval OS_STATUS_TIMED_OUT         time out exceeded
  */
-OS_API os_status_t os_system_run_wait(
-	const char *command,
-	int *exit_status,
-	os_bool_t privileged,
-	int priority,
-	size_t stack_size,
-	char *out_buf[2u],
-	size_t out_len[2u],
-	os_millisecond_t max_time_out );
+OS_API os_status_t os_system_run(
+	os_system_run_args_t *args );
 
 /**
  * @brief Shutdown or reboot the device
@@ -1760,7 +1826,8 @@ OS_API os_status_t os_system_run_wait(
  * @retval OS_STATUS_NOT_EXECUTABLE    shutdown failed to be triggered
  */
 OS_API os_status_t os_system_shutdown(
-	os_bool_t reboot, unsigned int delay
+	os_bool_t reboot,
+	unsigned int delay
 );
 
 /**

--- a/src/os_vxworks.c
+++ b/src/os_vxworks.c
@@ -71,12 +71,12 @@ os_status_t os_file_chown(
 	return OS_STATUS_FAILURE;
 }
 
-
 /* process functions */
 os_status_t os_path_executable(
 	char *path,
 	size_t size )
 {
+
 	os_status_t result = OS_STATUS_BAD_PARAMETER;
 	if ( path )
 	{
@@ -84,8 +84,8 @@ os_status_t os_path_executable(
 		result = OS_STATUS_FAILURE;
 		if (task_name && size > 2u)
 		{
-			path[0] = OS_DIR_SEP;
-			strncpy(&path[1], task_name, size - 1u);
+			strncpy(&path[0u], task_name, size - 1u);
+			path[size - 1u] = '\0';
 			result = OS_STATUS_SUCCESS;
 		}
 	}
@@ -314,116 +314,207 @@ static void os_vxworks_shutdown( void )
 #endif /* _WRS_CONFIG_SYS_PWR_OFF */
 
 static os_status_t os_vxworks_script(
-	char * script )
+	const char * script )
 {
 	os_status_t result = OS_STATUS_FAILURE;
-	char * shellTaskName;
+	char * shell_task_name;
 	int fd;
 
-	if ((fd = open(script, O_RDONLY, 0)) == ERROR) {
+	if ( ( fd = open( script, O_RDONLY, 0 ) ) == ERROR ) {
 		return OS_STATUS_FAILURE;
 	}
 
-	if (shellGenericInit("INTERPRETER=C", 0, NULL, &shellTaskName, FALSE,
-		FALSE, fd, STD_OUT, STD_ERR) == OK) {
+	if ( shellGenericInit( "INTERPRETER=C", 0, NULL, &shell_task_name,i
+		FALSE, FALSE, fd, STD_OUT, STD_ERR ) == OK ) {
 		result = OS_STATUS_SUCCESS;
 	}
 
 	do {
-		taskDelay(sysClkRateGet());
-	} while (taskNameToId(shellTaskName) != TASK_ID_ERROR);
+		taskDelay( sysClkRateGet() );
+	} while ( taskNameToId( shell_task_name ) != TASK_ID_ERROR );
 
-	close(fd);
+	close( fd );
 
 	return result;
 }
 #endif /* _WRS_KERNEL */
 
 os_status_t os_system_run(
-	const char *command,
-	int *exit_status,
-	os_bool_t privileged,
-	int priority,
-	size_t stack_size,
-	os_file_t pipe_files[2u] )
+	os_system_run_args_t *args )
 {
-	static const char * argv[10];
-	int argc = 0;
+	unsigned int i;
+	char **argv = NULL;
+	int argc = 0, argc_total;
+	os_bool_t is_executable = OS_FALSE;
+
+	if ( !args || (!args->cmd && !args->fptr) )
+		return OS_STATUS_BAD_PARAMETER;
 
 	/* set a default exit status */
-
-	if ( exit_status )
-		*exit_status = -1;
+	args->return_code = -1;
 
 	/* tokenize the command */
-	argv[argc] = strtok (command, " ");
-	while ((argv[argc] != NULL) && (++argc < 9)) {
-		argv[argc] = strtok (NULL, " ");
-	}
-	argv[9] = NULL;
-
-	/*
-	 * Go through list of supported commands
+	/* converts: "a.out \"param 1\" param2 param3"
+	 * to: argv[0] = "a.out"
+	 *     argv[1] = "param 1"
+	 *     argv[2] = "param2"
+	 *     argv[3] = "param3"
+	 *     argv[4] = NULL
+	 *
+	 * 2 passes: - 1) calculate amount of memory to dynamically allocate
+	 *           - 2) store values in allocated memory
 	 */
-#if defined(_WRS_KERNEL)
-	if (strstr (argv[0], "iot-control") != NULL) {
-		if (taskSpawn ("tControl",
-			priority, /*deviceCloudPriorityGet(), */ 0,
-			stack_size, /* deviceCloudStackSizeGet(), */
-			(FUNCPTR) control_main,
-			argc, argv, 0, 0, 0, 0, 0, 0, 0, 0) == TASK_ID_ERROR) {
-			return OS_STATUS_FAILURE;
+	for ( i = 0u; i < 2u; ++i )
+	{
+		size_t cmd_len = 0u;
+		char in_quote = '\0';
+		const char *cmd_pos, *cmd_start = args->cmd;
+		int ignore_next = 0;
+		argc = 0;
+		cmd_pos = args->cmd;
+		while ( cmd_pos )
+		{
+			/* handle quoted arguments */
+			if ( !ignore_next && ((in_quote == '\0' && (*cmd_pos == '\"' || *cmd_pos == '\'')) ||
+				(in_quote != '\0' && *cmd_pos == in_quote)))
+			{
+				if ( in_quote == '\0' )
+					in_quote = *cmd_pos;
+				else
+					in_quote = '\0';
+			}
+			else if ( (!ignore_next && in_quote == '\0' && *cmd_pos == ' ') || *cmd_pos == '\0')
+			{
+				size_t arg_len = cmd_pos - cmd_start;
+				if ( i > 0u )
+				{
+					char *d;
+					argv[argc] = ((char *)argv + (sizeof(char*) * (argc_total + 1)) + cmd_len);
+					strncpy(argv[argc], cmd_start, arg_len);
+					argv[argc][arg_len] = '\0';
+					argv[argc + 1] = NULL;
+				}
+				cmd_start = cmd_pos + 1;
+				cmd_len += arg_len + 1;
+				++argc;
+			}
+
+			if ( ignore_next )
+				ignore_next = 0;
+			else if ( *cmd_pos == '\\' )
+				ignore_next = 1;
+
+			if ( *cmd_pos == '\0' )
+				cmd_pos = NULL;
+			else
+				++cmd_pos;
 		}
-	} else if (strstr (argv[0], "iot-update") != NULL) {
-		if (taskSpawn ("tUpdate",
-			priority, /* deviceCloudPriorityGet(), */ 0,
-			stack_size, /* deviceCloudStackSizeGet(), */
-			(FUNCPTR) iot_update_main,
-			argc, argv, 0, 0, 0, 0, 0, 0, 0, 0) == TASK_ID_ERROR) {
-			return OS_STATUS_FAILURE;
+
+		/* create array storage location */
+		if ( i == 0u )
+		{
+			int j;
+			argv = (char**)malloc((sizeof(char *) * (argc + 1)) +
+				              (sizeof(char) * (cmd_len + 1)));
+			argc_total = argc;
+			if ( argv )
+				argv[0] = NULL;
+			else
+				return OS_STATUS_FAILURE;
 		}
-	} else if (strncmp (argv[0], "sh", sizeof("sh")) == 0) {
-		if (os_vxworks_script(argv[1]) == OS_STATUS_FAILURE) {
-			return OS_STATUS_FAILURE;
+	}
+
+	/* determine if file points to an executable file */
+	if ( argv && argv[0]
+#if defined( _WRS_KERNEL )
+		&& !args->fptr
+#endif /* if defined( _WRS_KERNEL ) */
+	   )
+	{
+		FILE *fstream = fopen( argv[0], "r" );
+		if ( fstream )
+		{
+			/* test for ELF file format */
+			char buf[4u];
+			char elf_magic[4u] = { 0x7F, 'E', 'L', 'F' };
+			if ( fread( buf, sizeof(char), sizeof(buf), fstream)
+				== sizeof(buf) && memcmp(buf, elf_magic,
+				sizeof(elf_magic)) == 0)
+			{
+				is_executable = OS_TRUE;
+			}
+			fclose( fstream );
 		}
-	} else {
-		if (os_vxworks_script(argv[0]) == OS_STATUS_FAILURE) {
+	}
+
+	if ( is_executable != OS_FALSE )
+	{
+		int i;
+		const char *app_name = strrchr(argv[0], '/');
+		if ( !app_name )
+			app_name = argv[0];
+		else
+			++app_name;
+
+		/* rtpSpawn: Spawn Real-Time Process (task)
+		 * - process executable path
+		 * - command line array (must be NULL terminated)
+		 * - environment variables
+		 * - priority
+		 * - stack size
+		 * - RTP options
+		 * - task options
+		 */
+		if ( rtpSpawn( argv[0], argv, NULL,
+			args->priority, args->stack_size,
+			RTP_LOADED_WAIT, VX_FP_TASK) == RTP_ID_ERROR)
+		{
+			free( argv );
 			return OS_STATUS_FAILURE;
 		}
 	}
-#else
-	if (rtpSpawn(argv[0], argv, NULL,
-		priority, /*deviceCloudPriorityGet(), */
-		stack_size, /* deviceCloudStackSizeGet(),*/
-		RTP_LOADED_WAIT, VX_FP_TASK) == RTP_ID_ERROR) {
+#if defined( _WRS_KERNEL )
+	else if ( args->fptr )
+	{
+		const char *task_name = "fPtr";
+		if ( argv && argv[0] )
+			task_name = argv[0];
+		if (taskSpawn (task_name, args->priority, 0, args->stack_size,
+			(FUNCPTR)args->fptr,
+			argc, argv, 0, 0, 0, 0, 0, 0, 0, 0) == TASK_ID_ERROR)
+		{
+			if ( argv )
+				free( argv );
+			return OS_STATUS_FAILURE;
+		}
+	}
+	else if ( argv && argv[0] && strncmp (argv[0], "sh", 2) == 0 )
+	{
+		if (os_vxworks_script(argv[1]) == OS_STATUS_FAILURE)
+		{
+			free( argv );
+			return OS_STATUS_FAILURE;
+		}
+	}
+	else if ( argv && os_vxworks_script(argv[0]) == OS_STATUS_FAILURE )
+	{
+		free( argv );
 		return OS_STATUS_FAILURE;
 	}
-	else {
-	       printf("Invalid command:%s\n", command);
-	       return OS_STATUS_FAILURE;
+#else /* if defined( _WRS_KERNEL ) */
+	else
+	{
+		printf( "Invalid command: %s\n", args->cmd );
+		if ( argv )
+			free( argv );
+		return OS_STATUS_FAILURE;
 	}
-#endif /* defined(_WRS_KERNEL) */
+#endif /* else if defined( _WRS_KERNEL ) */
 
-	if ( exit_status )
-		*exit_status = 0;
-
+	args->return_code = 0;
+	if ( argv )
+		free( argv );
 	return OS_STATUS_SUCCESS;
-}
-
-os_status_t os_system_run_wait(
-	const char *command,
-	int *exit_status,
-	os_bool_t privileged,
-	int priority,
-	size_t stack_size,
-	char *out_buf[2u],
-	size_t out_len[2u],
-	os_millisecond_t UNUSED(max_time_out) )
-{
-	os_file_t pipes[2u] = {NULL, NULL};
-	os_status_t result = os_system_run(command, exit_status, privileged,
-		priority, stack_size, pipes);
-	return result;
 }
 
 os_status_t os_system_shutdown(

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -15,6 +15,7 @@
 set( TESTS
 	"adapters"
 	"env"
+	"run"
 	"time"
 )
 
@@ -24,15 +25,19 @@ set( OS_LIB ${TARGET}${TARGET_STATIC_SUFFIX} )
 
 include_directories( "${CMAKE_BINARY_DIR}/out" )
 
-# adapters test
+# adapter tests
 set( TEST_ADAPTERS_SRCS "adapters_test.c" )
 set( TEST_ADAPTERS_LIBS ${OS_LIB} )
 
-# env test
+# env tests
 set( TEST_ENV_SRCS "env_test.c" )
 set( TEST_ENV_LIBS ${OS_LIB} )
 
-# time test
+# system run tests
+set( TEST_RUN_SRCS "run_test.c" )
+set( TEST_RUN_LIBS ${OS_LIB} )
+
+# time tests
 set( TEST_TIME_SRCS "time_test.c" )
 set( TEST_TIME_LIBS ${OS_LIB} )
 

--- a/test/integration/run_test.c
+++ b/test/integration/run_test.c
@@ -1,0 +1,195 @@
+/**
+ * @file
+ * @brief source file containing integration tests for enviroment variable
+ *        functions
+ *
+ * @copyright Copyright (C) 2018 Wind River Systems, Inc. All Rights Reserved.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied."
+ */
+
+#include <os.h>
+
+#include "test_support.h"
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h> /* for SetEnvironmentVariable() function */
+#endif /* else ifdef _WIN32 */
+
+/* internal main function to test @p fptr function */
+static int test_run_main_func( int argc, char *argv[] )
+{
+	printf( "%s\n", argv[0] );
+	return 255; /* should be a value: 0 - 255 */
+}
+
+
+/* test os_system_run */
+static void test_os_system_run_parameter_blank( void **state )
+{
+	os_status_t rv;
+	os_system_run_args_t args = OS_SYSTEM_RUN_ARGS_INIT;
+
+	rv = os_system_run( &args );
+	assert_int_equal( rv, OS_STATUS_BAD_PARAMETER );
+}
+
+static void test_os_system_run_parameter_none( void **state )
+{
+	os_status_t rv;
+
+	rv = os_system_run( NULL );
+	assert_int_equal( rv, OS_STATUS_BAD_PARAMETER );
+}
+
+static void test_os_system_run_complex_cmd_background( void **state )
+{
+	os_status_t rv;
+	os_system_run_args_t args = OS_SYSTEM_RUN_ARGS_INIT;
+
+	args.cmd = "echo \"this is a test\"";
+	rv = os_system_run( &args );
+	assert_int_equal( rv, OS_STATUS_INVOKED );
+	assert_int_equal( args.return_code, 0 );
+}
+
+static void test_os_system_run_simple_cmd_background( void **state )
+{
+	os_status_t rv;
+	os_system_run_args_t args = OS_SYSTEM_RUN_ARGS_INIT;
+
+	args.cmd = "echo test";
+	rv = os_system_run( &args );
+	assert_int_equal( rv, OS_STATUS_INVOKED );
+	assert_int_equal( args.return_code, 0 );
+}
+
+static void test_os_system_run_complex_cmd_exit_code( void **state )
+{
+	char std_out[64u];
+	os_status_t rv;
+	os_system_run_args_t args = OS_SYSTEM_RUN_ARGS_INIT;
+
+	args.cmd = "echo this is a test";
+	args.block = OS_TRUE;
+	args.opts.block.std_out.buf = std_out;
+	args.opts.block.std_out.len = 64u;
+	rv = os_system_run( &args );
+	assert_int_equal( rv, OS_STATUS_SUCCESS );
+	assert_int_equal( args.return_code, 0 );
+#if defined( _WIN32 )
+	assert_string_equal( std_out, "this is a test\r\n" );
+#else /* if defined( _WIN32 ) */
+	assert_string_equal( std_out, "this is a test\n" );
+#endif /* else if defined( _WIN32 ) */
+}
+
+static void test_os_system_run_simple_cmd_exit_code( void **state )
+{
+	char std_out[64u];
+	os_status_t rv;
+	os_system_run_args_t args = OS_SYSTEM_RUN_ARGS_INIT;
+
+	args.cmd = "echo test";
+	args.block = OS_TRUE;
+	args.opts.block.std_out.buf = std_out;
+	args.opts.block.std_out.len = 64u;
+	rv = os_system_run( &args );
+	assert_int_equal( rv, OS_STATUS_SUCCESS );
+	assert_int_equal( args.return_code, 0 );
+#if defined( _WIN32 )
+	assert_string_equal( std_out, "test\r\n" );
+#else /* if defined( _WIN32 ) */
+	assert_string_equal( std_out, "test\n" );
+#endif /* else if defined( _WIN32 ) */
+}
+
+static void test_os_system_run_max_wait_timeout_exceeded( void **state )
+{
+	os_status_t rv;
+	os_system_run_args_t args = OS_SYSTEM_RUN_ARGS_INIT;
+
+	/* create a process that will take 5 seconds */
+#if defined( _WIN32 )
+	args.cmd = "timeout 5";
+#else /* if defined( _WIN32 ) */
+	args.cmd = "sleep 5";
+#endif /* else if defined( _WIN32 ) */
+	args.block = OS_TRUE;
+	args.opts.block.max_wait_time = 2000u; /* kill after 2000 milliseconds (2 secs) */
+	rv = os_system_run( &args );
+	assert_int_equal( rv, OS_STATUS_TIMED_OUT );
+	assert_int_equal( args.return_code, -1 );
+}
+
+static void test_os_system_run_max_wait_timeout_not_hit( void **state )
+{
+	os_status_t rv;
+	os_system_run_args_t args = OS_SYSTEM_RUN_ARGS_INIT;
+
+	/* create a process that will take 5 seconds */
+#if defined( _WIN32 )
+	args.cmd = "timeout 1";
+#else /* if defined( _WIN32 ) */
+	args.cmd = "sleep 1";
+#endif /* else if defined( _WIN32 ) */
+	args.block = OS_TRUE;
+	args.opts.block.max_wait_time = 2000u; /* kill after 2000 milliseconds (2 secs) */
+	rv = os_system_run( &args );
+	assert_int_equal( rv, OS_STATUS_SUCCESS );
+	assert_int_equal( args.return_code, 0 );
+}
+
+static void test_os_system_run_fptr( void **state )
+{
+	char std_out[64u];
+	os_status_t rv;
+	os_system_run_args_t args = OS_SYSTEM_RUN_ARGS_INIT;
+
+	args.fptr = test_run_main_func;
+	args.cmd = "test_run_main_func running!";
+	args.block = OS_TRUE;
+	args.opts.block.std_out.buf = std_out;
+	args.opts.block.std_out.len = 64u;
+	rv = os_system_run( &args );
+
+#if defined( _WIN32 )
+	assert_int_equal( rv, OS_STATUS_NOT_SUPPORTED );
+	assert_int_equal( args.return_code, -1 );
+#else /* if defined( _WIN32 ) */
+	assert_int_equal( rv, OS_STATUS_SUCCESS );
+	assert_int_equal( args.return_code, 255 );
+	assert_string_equal( std_out, "test_run_main_func running!\n" );
+#endif /* else if defined( _WIN32 ) */
+}
+
+int main( int argc, char *argv[] )
+{
+	int result;
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test( test_os_system_run_parameter_blank ),
+		cmocka_unit_test( test_os_system_run_parameter_none ),
+		cmocka_unit_test( test_os_system_run_complex_cmd_background ),
+		cmocka_unit_test( test_os_system_run_simple_cmd_background ),
+		cmocka_unit_test( test_os_system_run_complex_cmd_exit_code ),
+		cmocka_unit_test( test_os_system_run_simple_cmd_exit_code ),
+		cmocka_unit_test( test_os_system_run_max_wait_timeout_exceeded ),
+		cmocka_unit_test( test_os_system_run_max_wait_timeout_not_hit ),
+		cmocka_unit_test( test_os_system_run_fptr )
+	};
+
+	test_initialize( argc, argv );
+	result = cmocka_run_group_tests( tests, NULL, NULL );
+	test_finalize( argc, argv );
+	return result;
+}
+


### PR DESCRIPTION
This patch updates the os_system_run function to take arguments as a
structure.  This is due to the increasing number of arguments.  This
will help when more arguments are required for additional platform
support (such as vxworks).

Signed-off-by: Keith Holman <keith.holman@windriver.com>