### PR TITLE
Sudo fixes

### DIFF
--- a/src/os_vxworks.c
+++ b/src/os_vxworks.c
@@ -40,11 +40,6 @@ extern BOOT_PARAMS sysBootParams;
 
 #define VX_RW_SEM_MAX_READERS (255)
 
-/**
- * @brief Seconds in one minute
- */
-#define SECONDS_IN_MINUTE 60u
-
 #if defined(_WRS_KERNEL)
 extern int control_main ( int argc, char* argv[] );
 extern int iot_update_main ( int argc, char* argv[] );
@@ -303,7 +298,7 @@ os_status_t os_thread_rwlock_destroy(
 static void os_vxworks_reboot( int delay )
 {
 	/* Wait 5 seconds for messages to propagate */
-	delay *= SECONDS_IN_MINUTE;
+	delay *= OS_SECONDS_IN_MINUTE;
 	if ( delay < 5 )
 		delay = 5;
 	sleep( delay );
@@ -315,7 +310,7 @@ static void os_vxworks_reboot( int delay )
 static void os_vxworks_shutdown( int delay )
 {
 	/* Wait 5 seconds for messages to propagate */
-	delay *= SECONDS_IN_MINUTE;
+	delay *= OS_SECONDS_IN_MINUTE;
 	if ( delay < 5 )
 		delay = 5;
 

--- a/src/os_win.c
+++ b/src/os_win.c
@@ -3489,10 +3489,10 @@ os_status_t os_system_shutdown(
 
 	if ( reboot == OS_FALSE )
 		os_snprintf( cmd, PATH_MAX, "%s %d", "shutdown /s /t ",
-			delay * SECONDS_IN_MINUTE );
+			delay * OS_SECONDS_IN_MINUTE );
 	else
 		os_snprintf( cmd, PATH_MAX, "%s %d", "shutdown /r /t ",
-			delay * SECONDS_IN_MINUTE );
+			delay * OS_SECONDS_IN_MINUTE );
 
 	args.cmd = cmd;
 	args.privileged = OS_TRUE;

--- a/test/integration/adapters_test.c
+++ b/test/integration/adapters_test.c
@@ -365,10 +365,10 @@ static void print_adapters( struct adapter *adapter )
 			for ( i = 0u; i < adapter->mac_len; ++i )
 			{
 				if ( i > 0u )
-					printf( ":" );
-				printf("%02x", adapter->mac[i] & 0xff);
+					os_printf( ":" );
+				os_printf("%02x", adapter->mac[i] & 0xff);
 			}
-			printf("\n");
+			os_printf("\n");
 		}
 
 		while ( ip )


### PR DESCRIPTION
3 fixes for the osal layer:
1) update the adapters test to display debug output properly
2) remove the "SECONDS_IN_MINUTE" symbol, as there is a symbol "OS_SECONDS_IN_MINUTE" already defined
3) fix the implementation for running the "privileged" commands in Linux correct and add an integration to test it accordingly.