### PR TITLE
servent: add service entry functions to osal

### DIFF
--- a/src/os.h.in
+++ b/src/os.h.in
@@ -1472,7 +1472,6 @@ OS_API os_status_t os_service_query(
 	os_millisecond_t max_time_out
 );
 
-/* socket functions */
 /**
  * @brief Get the IP address that a host resolves to
  *
@@ -1486,7 +1485,7 @@ OS_API os_status_t os_service_query(
  * @retval 0       on success
  * @retval !0      on failure (see getaddrinfo() return codes)
  */
- OS_API int os_get_host_address(
+OS_API int os_get_host_address(
 	const char *host,
 	const char *service,
 	char *address,
@@ -1494,6 +1493,7 @@ OS_API os_status_t os_service_query(
 	int family
 );
 
+/* socket functions */
 /**
  * @brief Accepts an incoming connection
  *

--- a/src/os_posix.c
+++ b/src/os_posix.c
@@ -1305,7 +1305,6 @@ os_bool_t os_path_is_absolute( const char *path )
 	return result;
 }
 
-/* socket functions */
 int os_get_host_address(
 	const char *host,
 	const char *service,
@@ -1357,6 +1356,7 @@ int os_get_host_address(
 	return result;
 }
 
+/* socket functions */
 os_status_t os_socket_accept(
 	const os_socket_t *socket,
 	os_socket_t **out,
@@ -1870,6 +1870,41 @@ unsigned long os_strtoul(
 	return strtoul( str, endptr, 10 );
 }
 #endif /* if defined( OSAL_WRAP ) */
+
+/* service entry (servent) functions */
+#if !defined( __VXWORKS__ )
+#if defined(OSAL_WRAP) && OSAL_WRAP
+os_service_entry_t *os_service_entry_by_name(
+	const char *name,
+	const char *proto )
+{
+	return (os_service_entry_t *)getservbyname( name, proto );
+}
+
+os_service_entry_t *os_service_entry_by_port(
+	int port,
+	const char *proto )
+{
+	return (os_service_entry_t *)getservbyport( port, proto );
+}
+
+void os_service_entry_close( void )
+{
+	endservent();
+}
+
+os_service_entry_t *os_service_entry_get( void )
+{
+	return (os_service_entry_t *)getservent();
+}
+
+void os_service_entry_open(
+	int stayopen )
+{
+	setservent( stayopen );
+}
+#endif /* if defined(OSAL_WRAP) && OSAL_WRAP */
+#endif /* if !defined( __VXWORKS__ ) */
 
 #if defined(OSAL_WRAP) && OSAL_WRAP
 /* operating system specific */

--- a/src/os_posix_private.h
+++ b/src/os_posix_private.h
@@ -45,7 +45,6 @@
 #include <fcntl.h>      /* for open, O_WRONLY, O_CREAT, O_EXCL, S_IRUSR,
                           S_IWUSR, S_IRGRP, S_IROTH */
 #include <limits.h>     /* for PATH_MAX */
-#include <netdb.h>      /* for struct addrinfo */
 #include <pthread.h>    /* for threading support */
 #include <signal.h>     /* for siginfo_t */
 #include <sys/socket.h> /* for struct addrinfo */

--- a/src/os_vxworks.c
+++ b/src/os_vxworks.c
@@ -97,6 +97,38 @@ os_status_t os_process_cleanup( void )
 	return OS_STATUS_FAILURE;
 }
 
+/* service entry (servent) functions */
+os_service_entry_t *os_service_entry_by_name(
+	const char *name,
+	const char *proto )
+{
+	return NULL;
+}
+
+os_service_entry_t *os_service_entry_by_port(
+	int port,
+	const char *proto )
+{
+	return NULL;
+}
+
+void os_service_entry_close( void )
+{
+	/* nothing to do on VxWorks */
+}
+
+os_service_entry_t *os_service_entry_get( void )
+{
+	return NULL;
+}
+
+void os_service_entry_open(
+	int stayopen )
+{
+	/* nothing to do on VxWorks */
+	(void)stayopen;
+}
+
 /* service functions */
 os_status_t os_service_run(
 	const char *id,

--- a/src/os_win.h
+++ b/src/os_win.h
@@ -157,6 +157,11 @@ typedef HANDLE os_file_t;
 typedef HMODULE os_lib_handle;
 
 /**
+ * @brief type represent a service entry
+ */
+typedef struct servent os_service_entry_t;
+
+/**
  * @brief Handle to a thread
  */
 typedef HANDLE os_thread_t;
@@ -771,6 +776,80 @@ OS_API void os_memzero(
 );
 #endif
 
+/* service entry (servent) functions */
+/**
+ * @brief Finds a service entry by service name
+ *
+ * @note This is equivilent to the @p getservbyname POSIX function
+ *
+ * @note This function will open the service entry database if required
+ *
+ * @param[in]      name                service name to search for
+ * @param[in]      proto               protocol to search for (optional)
+ *
+ * @return a pointer to the service entry if found.  NULL otherwise
+ *
+ * @see os_service_entry_by_port
+ * @see os_service_entry_close
+ */
+OS_API os_service_entry_t *os_service_entry_by_name(
+	const char *name,
+	const char *proto );
+
+/**
+ * @brief Finds a service entry by port
+ *
+ * @note This is equivilent to the @p getservbyport POSIX function
+ *
+ * @note This function will open the service entry database if required
+ *
+ * @param[in]      port                service port to search for
+ * @param[in]      proto               protocol to search for (optional)
+ *
+ * @return a pointer to the service entry if found.  NULL otherwise
+ *
+ * @see os_service_entry_by_name
+ * @see os_service_entry_close
+ */
+OS_API os_service_entry_t *os_service_entry_by_port(
+	int port,
+	const char *proto );
+
+/**
+ * @brief Closes the service entry database if open
+ *
+ * @note This is equivilent to the @p endservent POSIX function
+ *
+ * @see os_service_entry_get
+ * @see os_service_entry_open
+ */
+OS_API void os_service_entry_close( void );
+
+/**
+ * @brief Retrieves the next service entry from the database
+ *
+ * @note This is equivilent to the @p getservent POSIX function
+ *
+ * @return the next entry in the service database
+ *
+ * @see os_service_entry_open
+ * @see os_service_entry_close
+ */
+OS_API os_service_entry_t *os_service_entry_get( void );
+
+/**
+ * @brief Opens the service entry database
+ *
+ * @note This is equivilent to the @p setservent POSIX function
+ *
+ * @param[in]      stayopen            whether to keep the database open
+ *
+ * @see os_service_entry_get
+ * @see os_service_entry_close
+ */
+OS_API void os_service_entry_open(
+	int stayopen );
+
 /**
  * @brief Returns the operating system code for the last system error
  *        encountered
@@ -1051,3 +1130,4 @@ OS_API os_status_t os_thread_condition_wait(
 );
 #endif
 #endif /* if OSAL_THREAD_SUPPORT */
+

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -16,6 +16,7 @@ set( TESTS
 	"adapters"
 	"env"
 	"run"
+	"service_entry"
 	"time"
 )
 
@@ -36,6 +37,10 @@ set( TEST_ENV_LIBS ${OS_LIB} )
 # system run tests
 set( TEST_RUN_SRCS "run_test.c" )
 set( TEST_RUN_LIBS ${OS_LIB} )
+
+# service entry tests
+set( TEST_SERVICE_ENTRY_SRCS "service_entry_test.c" )
+set( TEST_SERVICE_ENTRY_LIBS ${OS_LIB} )
 
 # time tests
 set( TEST_TIME_SRCS "time_test.c" )

--- a/test/integration/service_entry_test.c
+++ b/test/integration/service_entry_test.c
@@ -1,0 +1,199 @@
+/**
+ * @file
+ * @brief source file containing integration tests for service entry functions
+ *
+ * @copyright Copyright (C) 2018 Wind River Systems, Inc. All Rights Reserved.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied."
+ */
+
+#include <os.h>
+
+#include "test_support.h"
+
+#if !defined(VERBOSE)
+#define VERBOSE 0
+#endif /* if !defined(VERBOSE) */
+
+/**
+ * @brief object to assoicate names and ports
+ */
+struct name_port
+{
+	const char *name;           /**< @brief service name */
+	const char *proto;          /**< @brief service protocol (optional) */
+	int port;                   /**< @brief service port */
+};
+
+/**
+ * @brief contains a list of known ports for testing purposes
+ */
+static struct name_port known_services[] = {
+	{ "http", "tcp", 80 },
+	{ "ssh", NULL, 22 } ,
+	{ "telnet", "tcp", 23 },
+#if defined( __APPLE__ )
+	{ "smtp", NULL, 25 },
+#else /* if defined( __APPLE__ ) */
+	{ "mail", NULL, 25 }, /* find via aliases (for stmp) */
+#endif /* else if defined( __APPLE__ ) */
+	{ NULL, NULL, 0 }
+};
+
+static struct name_port unknown_services[] = {
+	{ "bad-service", "tcp", 8007 },
+	{ "no-service", "udp", 8012 },
+	{ "nothing-service", NULL, 8120 },
+	{ NULL, NULL, 0 }
+};
+
+static void test_os_service_entry_find_by_name_known( void **state )
+{
+	const struct name_port *known_service = &known_services[0u];
+	while ( known_service->name )
+	{
+		unsigned int i = 0u;
+		const char *s_name;
+		const os_uint16_t port_le =
+			htons((uint16_t)known_service->port);
+		os_service_entry_t *res =
+			os_service_entry_by_name(
+				known_service->name, known_service->proto );
+
+		os_printf( "testing service: %s\n", known_service->name );
+		assert_non_null( res );
+		s_name = res->s_name;
+		while ( res->s_aliases && res->s_aliases[i] )
+		{
+			if ( os_strcmp( res->s_aliases[i], known_service->name ) == 0 )
+				s_name = res->s_aliases[i];
+			++i;
+		}
+		assert_string_equal( s_name, known_service->name );
+		assert_int_equal( res->s_port, port_le );
+
+		++known_service;
+	}
+
+	os_service_entry_close();
+}
+
+static void test_os_service_entry_find_by_name_unknown( void **state )
+{
+	const struct name_port *unknown_service = &unknown_services[0u];
+	while ( unknown_service->name )
+	{
+		os_service_entry_t *res =
+			os_service_entry_by_name(
+				unknown_service->name, unknown_service->proto );
+		assert_null( res );
+		++unknown_service;
+	}
+	os_service_entry_close();
+}
+
+static void test_os_service_entry_find_by_port_known( void **state )
+{
+	const struct name_port *known_service = &known_services[0u];
+	while ( known_service->name )
+	{
+		unsigned int i = 0u;
+		const char *s_name;
+		const os_uint16_t port_le =
+			htons((uint16_t)known_service->port);
+		os_service_entry_t *const res =
+			os_service_entry_by_port( port_le, known_service->proto );
+
+		os_printf( "testing port: %d\n", known_service->port );
+		assert_non_null( res );
+		s_name = res->s_name;
+		while ( res->s_aliases && res->s_aliases[i] )
+		{
+			if ( os_strcmp( res->s_aliases[i], known_service->name ) == 0 )
+				s_name = res->s_aliases[i];
+			++i;
+		}
+		assert_string_equal( s_name, known_service->name );
+		assert_int_equal( res->s_port, port_le );
+
+		++known_service;
+	}
+	os_service_entry_close();
+}
+
+static void test_os_service_entry_find_by_port_unknown( void **state )
+{
+	const struct name_port *unknown_service = &unknown_services[0u];
+	while ( unknown_service->name )
+	{
+		const os_uint16_t port_le =
+			htons((uint16_t)unknown_service->port);
+		os_service_entry_t *const res =
+			os_service_entry_by_port( port_le, unknown_service->proto );
+
+		assert_null( res );
+		++unknown_service;
+	}
+	os_service_entry_close();
+}
+
+static void test_os_service_entry_list_all( void **state )
+{
+	os_service_entry_t *cur;
+	os_service_entry_open( 1 );
+
+	cur = os_service_entry_get();
+#if VERBOSE
+	os_printf( "known services: \n" );
+#endif /* if VERBOSE */
+	while ( cur )
+	{
+		assert_non_null( cur->s_name );
+		assert_non_null( cur->s_proto );
+#if VERBOSE
+		os_printf( " %d, %s, %s", ntohs((uint16_t)cur->s_port), cur->s_proto,
+			cur->s_name );
+		if ( cur->s_aliases )
+		{
+			size_t i = 0u;
+			while ( cur->s_aliases[i] )
+			{
+				os_printf( ", %s", cur->s_aliases[i] );
+				++i;
+			}
+		}
+		os_printf( "\n" );
+#endif /* if VERBOSE */
+		assert_in_range( ntohs((uint16_t)cur->s_port), 1, 65535 );
+		cur = os_service_entry_get();
+	}
+
+	os_service_entry_close();
+}
+
+
+int main( int argc, char *argv[] )
+{
+	int result;
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test( test_os_service_entry_find_by_name_known ),
+		cmocka_unit_test( test_os_service_entry_find_by_name_unknown ),
+		cmocka_unit_test( test_os_service_entry_find_by_port_known ),
+		cmocka_unit_test( test_os_service_entry_find_by_port_unknown ),
+		cmocka_unit_test( test_os_service_entry_list_all )
+	};
+
+	test_initialize( argc, argv );
+	result = cmocka_run_group_tests( tests, NULL, NULL );
+	test_finalize( argc, argv );
+	return result;
+}
+


### PR DESCRIPTION
This patch adds functions that mirror the POSIX service entry (servent)
functions: `getservent`, `getservbyname`, `getservbyport`, `setservant`,
and `endservant`.  This allows for clients of this library to utilize
the service entry functions without worrying about required headers for
a particular platform.

Signed-off-by: Keith Holman <keith.holman@windriver.com>